### PR TITLE
master/train: fix mariadb-bootstrap-resolveip-issue.patch

### DIFF
--- a/patches/master/mariadb-bootstrap-resolveip-issue.patch
+++ b/patches/master/mariadb-bootstrap-resolveip-issue.patch
@@ -5,6 +5,6 @@
    - "{{ node_config_directory }}/mariadb/:{{ container_config_directory }}/:ro"
    - "/etc/localtime:/etc/localtime:ro"
 +  - "/etc/hosts:/etc/hosts:ro"
+   - "{{ '/etc/timezone:/etc/timezone:ro' if kolla_base_distro in ['debian', 'ubuntu'] else '' }}"
    - "mariadb:/var/lib/mysql"
    - "kolla_logs:/var/log/kolla/"
- mariadb_extra_volumes: "{{ default_extra_volumes }}"

--- a/patches/train/mariadb-bootstrap-resolveip-issue.patch
+++ b/patches/train/mariadb-bootstrap-resolveip-issue.patch
@@ -5,6 +5,6 @@
    - "{{ node_config_directory }}/mariadb/:{{ container_config_directory }}/:ro"
    - "/etc/localtime:/etc/localtime:ro"
 +  - "/etc/hosts:/etc/hosts:ro"
+   - "{{ '/etc/timezone:/etc/timezone:ro' if kolla_base_distro in ['debian', 'ubuntu'] else '' }}"
    - "mariadb:/var/lib/mysql"
    - "kolla_logs:/var/log/kolla/"
- mariadb_extra_volumes: "{{ default_extra_volumes }}"


### PR DESCRIPTION
Required because of https://review.opendev.org/#/c/704258/.