### PR TITLE
stein: remove disable-kibana-post-config.patch

### DIFF
--- a/patches/stein/disable-kibana-post-config.patch
+++ b/patches/stein/disable-kibana-post-config.patch
@@ -1,8 +1,0 @@
---- a/ansible/roles/kibana/tasks/deploy.yml
-+++ b/ansible/roles/kibana/tasks/deploy.yml
-@@ -3,5 +3,3 @@
- 
- - name: Flush handlers
-   meta: flush_handlers
--
--- include_tasks: post_config.yml


### PR DESCRIPTION
No longer required because of https://review.opendev.org/#/c/735839/.