### PR TITLE
Fix secrets.sh

### DIFF
--- a/files/scripts/secrets.sh
+++ b/files/scripts/secrets.sh
@@ -25,4 +25,7 @@ file_env() {
 }
 
 NETBOX_TOKEN_FILE=${NETBOX_TOKEN_FILE:-/run/secrets/NETBOX_TOKEN}
-file_env 'NETBOX_TOKEN'
+
+if [[ -e $NETBOX_TOKEN_FILE ]]; then
+    file_env 'NETBOX_TOKEN'
+fi


### PR DESCRIPTION
/secrets.sh: line 21: /run/secrets/NETBOX_TOKEN: No such file or directory

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>