### PR TITLE
github: disable build of old stable releases

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -25,10 +25,6 @@ jobs:
     strategy:
       matrix:
         openstack_version:
-          - rocky
-          - stein
-          - train
-          - ussuri
           - victoria
           - master
     steps:


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>