### PR TITLE
Remove sudo

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -40,8 +40,6 @@ COPY files/ansible.cfg /etc/ansible/ansible.cfg
 COPY files/requirements.yml /ansible/galaxy/requirements.yml
 COPY files/refresh-containers.yml /tmp/refresh-containers.yml
 
-COPY files/dragon_sudoers /etc/sudoers.d/dragon_sudoers
-
 COPY files/src /src
 
 # add inventory files
@@ -79,7 +77,6 @@ RUN apt-get update \
         python3-wheel \
         rsync \
         sshpass \
-        sudo \
         vim-tiny \
     && python3 -m pip install --upgrade pip \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
@@ -87,8 +84,7 @@ RUN apt-get update \
 
 # add user
 
-RUN chmod 0440 /etc/sudoers.d/dragon_sudoers \
-    && groupadd -g $GROUP_ID dragon \
+RUN groupadd -g $GROUP_ID dragon \
     && groupadd -g $GROUP_ID_DOCKER docker \
     && useradd -g dragon -G docker -u $USER_ID -m -d /ansible dragon
 

--- a/files/dragon_sudoers
+++ b/files/dragon_sudoers
@@ -1,6 +1,0 @@
-# This is a workaround to be able to run local actions with sudo without requiring a password.
-#
-# This behaviour should be fixed in kolla-ansible itself, local actions should not be use sudo
-# when it is not required.
-
-dragon ALL=(root) NOPASSWD: ALL


### PR DESCRIPTION
If still present, become* parameters in environments/kolla/configuration.yml
must be removed from now on.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>