### PR TITLE
Install hiredis

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -10,6 +10,7 @@ ara[server]=={{ osism_projects['ara'] }}
 asn1crypto
 celery[redis]==5.2.0
 cryptography
+hiredis
 idna
 paramiko
 proxmoxer


### PR DESCRIPTION
UserWarning: redis-py works best with hiredis.

Signed-off-by: Christian Berendt <berendt@osism.tech>