### PR TITLE
Use pip install --no-cache-dir

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -84,7 +84,7 @@ RUN git clone https://github.com/osism/release /release
 # prepare python-osism repository
 # hadolint ignore=DL3013
 RUN git clone https://github.com/osism/python-osism /python-osism \
-    && pip3 install /python-osism
+    && pip3 install --no-cache-dir /python-osism
 
 # prepare project repository
 


### PR DESCRIPTION
DL3042 warning: Avoid use of cache directory with pip.
Use `pip install --no-cache-dir <package>`

Signed-off-by: Christian Berendt <berendt@osism.tech>