### PR TITLE
github: remove victoria build

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         openstack_version:
-          - victoria
           - wallaby
           - xena
           - master


### PR DESCRIPTION
Xena + Wallaby are active. Bye, Bye Victoria

Signed-off-by: Christian Berendt <berendt@osism.tech>