### PR TITLE
Revert "chore(deps): update dependency jinja2 to v3.1.0 (#235)"

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==3.1.0
+Jinja2==3.0.3  # https://review.opendev.org/c/openstack/kolla-ansible/+/835090
 PyYAML==6.0
 pottery==3.0.0
 yq==2.14.0


### PR DESCRIPTION
https://review.opendev.org/c/openstack/kolla-ansible/+/835090

---snip---
Pin Jinja2<3.1.0 to avoid Python 3.6 drop

Jinja2 drops support for Python 3.6, and removes the contextfilter
function which is used Kolla Ansible. The following warning is seen:

    [WARNING]: Skipping plugin (filters.py) as it seems to be invalid:
    module 'jinja2' has no attribute 'contextfilter'

This change fixes the issue by pinning Jinja2 to <3.1.0.
---snap---

This reverts commit 18e9dbbf0e675c86e97585aa3e27d760f422f7c2.