### PR TITLE
xena/yoga: use raw body to call /_flush/synced

### DIFF
--- a/patches/xena/elasticsearch-raw-instead-of-json.patch
+++ b/patches/xena/elasticsearch-raw-instead-of-json.patch
@@ -1,0 +1,11 @@
+--- a/ansible/roles/elasticsearch/tasks/upgrade.yml
++++ b/ansible/roles/elasticsearch/tasks/upgrade.yml
+@@ -26,7 +26,7 @@
+       method: POST
+       status_code: 200
+       return_content: yes
+-      body_format: json
++      body_format: raw
+   delegate_to: "{{ groups['elasticsearch'][0] }}"
+   run_once: true
+   retries: 10

--- a/patches/yoga/elasticsearch-raw-instead-of-json.patch
+++ b/patches/yoga/elasticsearch-raw-instead-of-json.patch
@@ -1,0 +1,11 @@
+--- a/ansible/roles/elasticsearch/tasks/upgrade.yml
++++ b/ansible/roles/elasticsearch/tasks/upgrade.yml
+@@ -26,7 +26,7 @@
+       method: POST
+       status_code: 200
+       return_content: yes
+-      body_format: json
++      body_format: raw
+   delegate_to: "{{ groups['elasticsearch'][0] }}"
+   run_once: true
+   retries: 10


### PR DESCRIPTION
POST /_flush/synced] does not support having a body

Closes osism/issues#290

Signed-off-by: Christian Berendt <berendt@osism.tech>