### PR TITLE
Remove note from requirements.txt

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==3.1.2  # https://review.opendev.org/c/openstack/kolla-ansible/+/835090
+Jinja2==3.1.2
 PyYAML==6.0
 osism==0.8.0
 pottery==3.0.0


### PR DESCRIPTION
https://review.opendev.org/c/openstack/kolla-ansible/+/835090 was abandoned and we use Python >= 3.8.

Signed-off-by: Christian Berendt <berendt@osism.tech>