### PR TITLE
Do not install vim

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -71,7 +71,6 @@ RUN apt-get update \
         python3-wheel \
         rsync \
         sshpass \
-        vim-tiny \
     && python3 -m pip install --no-cache-dir --upgrade 'pip==23.0' \
     && pip3 install --no-cache-dir -r /src/requirements.txt \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \


### PR DESCRIPTION
vim was sometimes used for debugging, troubleshooting, etc. In future, dedicated development images should be used for this, but such tools should not be included in the final images.

Signed-off-by: Christian Berendt <berendt@osism.tech>