### PR TITLE
zed: add kibana & elasticsearch playbooks

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ COPY files/library /ansible/library
 COPY files/plugins /ansible/plugins
 COPY files/tasks /ansible/tasks
 
-COPY files/playbooks/$OPENSTACK_VERSION/kolla-common.yml /ansible/kolla-common.yml
+COPY files/playbooks/$OPENSTACK_VERSION/kolla-*.yml /ansible/
 COPY files/playbooks/kolla-bifrost-keypair.yml /ansible/kolla-bifrost-keypair.yml
 COPY files/playbooks/kolla-facts.yml /ansible/kolla-facts.yml
 COPY files/playbooks/kolla-loadbalancer-*.yml /ansible/

--- a/files/playbooks/zed/kolla-elasticsearch.yml
+++ b/files/playbooks/zed/kolla-elasticsearch.yml
@@ -1,0 +1,27 @@
+---
+- name: Group hosts based on configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Group hosts based on Kolla action
+      ansible.builtin.group_by:
+        key: kolla_action_{{ kolla_action }}
+      changed_when: false
+    - name: Group hosts based on enabled services
+      ansible.builtin.group_by:
+        key: '{{ item }}'
+      changed_when: false
+      with_items:
+        - enable_opensearch_{{ enable_opensearch | bool }}
+        - enable_opensearch_dashboards_{{ enable_opensearch_dashboards | bool }}
+  tags: always
+
+- name: Apply role opensearch
+  gather_facts: false
+  hosts:
+    - opensearch
+    - '&enable_opensearch_True'
+  serial: '{{ kolla_serial|default("0") }}'
+  roles:
+    - role: opensearch
+      tags: opensearch

--- a/files/playbooks/zed/kolla-kibana.yml
+++ b/files/playbooks/zed/kolla-kibana.yml
@@ -1,0 +1,10 @@
+---
+- name: Apply role kibana
+  gather_facts: false
+  hosts:
+    - kibana
+
+  tasks:
+    - name: Kibana is no longer available
+      ansible.builtin.debug:
+        msg: Due to the switch to Opensearch, the Kibana role is no longer available.


### PR DESCRIPTION
This is a workaround so that old commands still work for now.

When elasticsearch is called, opensearch is used as a role.

When Kibana is called, a message is displayed that Kibana is no longer available.

Signed-off-by: Christian Berendt <berendt@osism.tech>