### PR TITLE
yoga: add horizon-use-static-python-version,patch

### DIFF
--- a/patches/yoga/horizon-use-static-python-version,patch
+++ b/patches/yoga/horizon-use-static-python-version,patch
@@ -1,0 +1,10 @@
+diff --git a/ansible/roles/horizon/templates/horizon.conf.j2 b/ansible/roles/horizon/templates/horizon.conf.j2
+index e9671a2d0..5439b3673 100644
+--- a/ansible/roles/horizon/templates/horizon.conf.j2
++++ b/ansible/roles/horizon/templates/horizon.conf.j2
+@@ -1,4 +1,4 @@
+-{% set python_path = '/usr/share/openstack-dashboard' if horizon_install_type == 'binary' else '/var/lib/kolla/venv/lib/python' + distro_python_version + '/site-packages' %}
++{% set python_path = '/var/lib/kolla/venv/lib/python3.8/site-packages' %}
+
+ {% if horizon_enable_tls_backend | bool %}
+ {% if kolla_base_distro in ['centos']  %}


### PR DESCRIPTION
Python 3.10 is already in use on Ubuntu 22.04. As we currently use both Ubuntu 20.04 and Ubuntu 22.04 for Yoga, it does not work to use the Python version of the underlying system as we always have the Python 3.8 version for Yoga in the Horizon container image.

Closes osism/issues#419

Signed-off-by: Christian Berendt <berendt@osism.tech>