### PR TITLE
Render playbooks

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -203,6 +203,9 @@ RUN ln -s /ansible/kolla-gather-facts.yml /ansible/gather-facts.yml \
 # copy ara configuration
 RUN python3 -m ara.setup.env > /ansible/ara.env
 
+# prepare list of playbooks
+RUN python3 /src/render-playbooks.py
+
 # set correct permssions
 RUN chown -R dragon: /ansible /share /interface
 

--- a/files/scripts/entrypoint.sh
+++ b/files/scripts/entrypoint.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-mkdir -p /interface/kolla-ansible /interface/versions /interface/overlays
+mkdir -p /interface/kolla-ansible /interface/versions /interface/overlays /interface/playbooks
 
 rsync -am --exclude='requirements*.yml' --include='*.yml' --exclude='*' /ansible/ /interface/kolla-ansible/
 cp /ansible/group_vars/all/versions.yml /interface/versions/kolla-ansible.yml
 cp /overlays/kolla-ansible.yml /interface/overlays/kolla-ansible.yml
+cp /ansible/playbooks.yml /interface/playbooks/kolla-ansible.yml
 
 exec /usr/bin/dumb-init -- "$@"

--- a/files/src/render-playbooks.py
+++ b/files/src/render-playbooks.py
@@ -1,0 +1,58 @@
+# This script writes a list of all existing playbooks to /ansible/playbooks.yml.
+
+from pathlib import Path
+
+import yaml
+
+PREFIX = "kolla"
+
+KEEP_PREFIX = [
+    "destroy",
+    "facts",
+    "gather-facts",
+    "prune-images",
+    "purge",
+    "rgw-endpoint",
+    "site",
+    "testbed",
+    "testbed-identity",
+]
+
+HIDE = [
+    "blazar",
+    "cyborg",
+    "freezer",
+    "influxdb",
+    "kafka",
+    "magnum",
+    "masakari",
+    "monasca",
+    "monasca_cleanup",
+    "murano",
+    "panko",
+    "qdrouterd",
+    "rally",
+    "sahara",
+    "solum",
+    "tacker",
+    "telegraf",
+    "tempest",
+    "vitrage",
+    "vmtp",
+    "watcher",
+    "zookeeper",
+]
+
+result = {}
+
+for path in Path("/ansible").glob(f"{PREFIX}-*.yml"):
+    name = path.with_suffix("").name[len(PREFIX) + 1 :]  # noqa E203
+
+    if name not in HIDE:
+        if name in KEEP_PREFIX:
+            result[f"{PREFIX}-{name}"] = PREFIX
+        else:
+            result[name] = PREFIX
+
+with open("/ansible/playbooks.yml", "w+") as fp:
+    fp.write(yaml.dump(result))


### PR DESCRIPTION
This script writes a list of all existing playbooks to /ansible/playbooks.yml.

Signed-off-by: Christian Berendt <berendt@osism.tech>