### PR TITLE
yoga: add kolla-ovn playbook

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -8,3 +8,4 @@ rules:
 # ignore playbooks imported from kolla-ansible upstream
 ignore: |
   kolla-loadbalancer-*.yml
+  kolla-ovn.yml

--- a/files/playbooks/yoga/kolla-ovn.yml
+++ b/files/playbooks/yoga/kolla-ovn.yml
@@ -1,0 +1,102 @@
+---
+- name: Group hosts based on configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Group hosts based on Kolla action
+      group_by:
+          key: kolla_action_{{ kolla_action }}
+      changed_when: false
+    - name: Group hosts based on enabled services
+      group_by:
+          key: '{{ item }}'
+      changed_when: false
+      with_items:
+        - enable_aodh_{{ enable_aodh | bool }}
+        - enable_barbican_{{ enable_barbican | bool }}
+        - enable_blazar_{{ enable_blazar | bool }}
+        - enable_ceilometer_{{ enable_ceilometer | bool }}
+        - enable_ceph_rgw_{{ enable_ceph_rgw | bool }}
+        - enable_cinder_{{ enable_cinder | bool }}
+        - enable_cloudkitty_{{ enable_cloudkitty | bool }}
+        - enable_collectd_{{ enable_collectd | bool }}
+        - enable_cyborg_{{ enable_cyborg | bool }}
+        - enable_designate_{{ enable_designate | bool }}
+        - enable_elasticsearch_{{ enable_elasticsearch | bool }}
+        - enable_etcd_{{ enable_etcd | bool }}
+        - enable_freezer_{{ enable_freezer | bool }}
+        - enable_glance_{{ enable_glance | bool }}
+        - enable_gnocchi_{{ enable_gnocchi | bool }}
+        - enable_grafana_{{ enable_grafana | bool }}
+        - enable_hacluster_{{ enable_hacluster | bool }}
+        - enable_heat_{{ enable_heat | bool }}
+        - enable_horizon_{{ enable_horizon | bool }}
+        - enable_influxdb_{{ enable_influxdb | bool }}
+        - enable_ironic_{{ enable_ironic | bool }}
+        - enable_iscsid_{{ enable_iscsid | bool }}
+        - enable_kafka_{{ enable_kafka | bool }}
+        - enable_keystone_{{ enable_keystone | bool }}
+        - enable_kibana_{{ enable_kibana | bool }}
+        - enable_kuryr_{{ enable_kuryr | bool }}
+        - enable_loadbalancer_{{ enable_loadbalancer | bool }}
+        - enable_magnum_{{ enable_magnum | bool }}
+        - enable_manila_{{ enable_manila | bool }}
+        - enable_mariadb_{{ enable_mariadb | bool }}
+        - enable_masakari_{{ enable_masakari | bool }}
+        - enable_memcached_{{ enable_memcached | bool }}
+        - enable_mistral_{{ enable_mistral | bool }}
+        - enable_monasca_{{ enable_monasca | bool }}
+        - enable_multipathd_{{ enable_multipathd | bool }}
+        - enable_murano_{{ enable_murano | bool }}
+        - enable_neutron_{{ enable_neutron | bool }}
+        - enable_nova_{{ enable_nova | bool }}
+        - enable_octavia_{{ enable_octavia | bool }}
+        - enable_openvswitch_{{ enable_openvswitch | bool }}_enable_ovs_dpdk_{{
+          enable_ovs_dpdk | bool }}
+        - enable_outward_rabbitmq_{{ enable_outward_rabbitmq | bool }}
+        - enable_ovn_{{ enable_ovn | bool }}
+        - enable_placement_{{ enable_placement | bool }}
+        - enable_prometheus_{{ enable_prometheus | bool }}
+        - enable_qdrouterd_{{ enable_qdrouterd | bool }}
+        - enable_rabbitmq_{{ enable_rabbitmq | bool }}
+        - enable_redis_{{ enable_redis | bool }}
+        - enable_sahara_{{ enable_sahara | bool }}
+        - enable_senlin_{{ enable_senlin | bool }}
+        - enable_skydive_{{ enable_skydive | bool }}
+        - enable_solum_{{ enable_solum | bool }}
+        - enable_storm_{{ enable_storm | bool }}
+        - enable_swift_{{ enable_swift | bool }}
+        - enable_tacker_{{ enable_tacker | bool }}
+        - enable_telegraf_{{ enable_telegraf | bool }}
+        - enable_trove_{{ enable_trove | bool }}
+        - enable_vitrage_{{ enable_vitrage | bool }}
+        - enable_watcher_{{ enable_watcher | bool }}
+        - enable_zookeeper_{{ enable_zookeeper | bool }}
+        - enable_zun_{{ enable_zun | bool }}
+  tags: always
+
+- name: Apply role ovn-db
+  gather_facts: no
+  hosts:
+    - ovn-nb-db
+    - ovn-northd
+    - ovn-sb-db
+    - '&enable_ovn_True'
+  serial: '{{ kolla_serial|default("0") }}'
+  roles:
+    - role: ovn-db
+      tags:
+        - ovn
+        - ovn-db
+
+- name: Apply role ovn-controller
+  gather_facts: no
+  hosts:
+    - ovn-controller
+    - '&enable_ovn_True'
+  serial: '{{ kolla_serial|default("0") }}'
+  roles:
+    - role: ovn-controller
+      tags:
+        - ovn
+        - ovn-controller


### PR DESCRIPTION
Required because of https://review.opendev.org/c/openstack/kolla-ansible/+/868744.

Via this backport, the role has now already been split into two roles in Yoga. Since we are still working with one role in Yoga, we need the wrapper playbook.

Signed-off-by: Christian Berendt <berendt@osism.tech>