### PR TITLE
yoga: add missing parameters

### DIFF
--- a/overlays/yoga/kolla-ansible.yml
+++ b/overlays/yoga/kolla-ansible.yml
@@ -17,3 +17,8 @@ kibana_log_prefix: "flog"
 
 elasticsearch_connection_string: "elasticsearch://{{ elasticsearch_address | put_address_in_context('url') }}:{{ elasticsearch_port }}"
 osprofiler_backend_connection_string: "{{ redis_connection_string if osprofiler_backend == 'redis' else elasticsearch_connection_string }}"
+
+enable_common: "yes"
+enable_opensearch: "no"
+opensearch_address: "{{ kolla_internal_fqdn }}"
+enable_opensearch_dashboards: "no"


### PR DESCRIPTION
Required because of some new backports on stable/yoga.