### PR TITLE
Pin ansible.posix version to 1.5.2

### DIFF
--- a/files/requirements.yml
+++ b/files/requirements.yml
@@ -10,8 +10,6 @@ collections:
     source: https://galaxy.ansible.com
   - name: ansible.netcommon
     source: https://galaxy.ansible.com
-  - name: ansible.posix
-    source: https://galaxy.ansible.com
   - name: ansible.utils
     source: https://galaxy.ansible.com
   - name: community.general
@@ -30,3 +28,8 @@ collections:
     source: https://galaxy.ansible.com
   - name: community.rabbitmq
     source: https://galaxy.ansible.com
+  # NOTE: versions > 1.5.2 currently triggers race conditions in various
+  #       stable/yoga roles (ovn, openvswitch)
+  - name: ansible.posix
+    source: https://galaxy.ansible.com
+    version: 1.5.2


### PR DESCRIPTION
versions > 1.5.2 currently triggers race conditions in various stable/yoga roles (ovn, openvswitch)