### PR TITLE
Disable build of master

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -18,7 +18,6 @@ jobs:
         openstack_version:
           - yoga
           - zed
-          - master
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
We do not use the master image for anything at the moment. Let's only build stable images for the moment.