### PR TITLE
zuul: install python3-docker

### DIFF
--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -7,6 +7,7 @@
       become: true
       ansible.builtin.apt:
         name:
+          - python3-docker
           - python3-requests
 
   roles:


### PR DESCRIPTION
Required by community.docker collection.