### PR TITLE
zed: add remove-openstack-auth-system-scope.patch

### DIFF
--- a/patches/zed/remove-openstack-auth-system-scope.patch
+++ b/patches/zed/remove-openstack-auth-system-scope.patch
@@ -1,0 +1,136 @@
+diff --git a/ansible/roles/heat/tasks/bootstrap_service.yml b/ansible/roles/heat/tasks/bootstrap_service.yml
+index 4aa7ea913..b97d2450a 100644
+--- a/ansible/roles/heat/tasks/bootstrap_service.yml
++++ b/ansible/roles/heat/tasks/bootstrap_service.yml
+@@ -16,7 +16,7 @@
+       OS_USERNAME: "{{ openstack_auth.username }}"
+       OS_PASSWORD: "{{ openstack_auth.password }}"
+       OS_USER_DOMAIN_NAME: "{{ openstack_auth.user_domain_name }}"
+-      OS_SYSTEM_SCOPE: "{{ openstack_auth.system_scope }}"
++      OS_SYSTEM_SCOPE: "all"
+       OS_REGION_NAME: "{{ openstack_region_name }}"
+       OS_CACERT: "{{ openstack_cacert | default(omit) }}"
+       HEAT_DOMAIN_ADMIN_PASSWORD: "{{ heat_domain_admin_password }}"
+diff --git a/ansible/roles/ironic/tasks/upgrade.yml b/ansible/roles/ironic/tasks/upgrade.yml
+index e4e268f4a..f771e8459 100644
+--- a/ansible/roles/ironic/tasks/upgrade.yml
++++ b/ansible/roles/ironic/tasks/upgrade.yml
+@@ -9,7 +9,7 @@
+     --os-password {{ openstack_auth.password }}
+     --os-identity-api-version 3
+     --os-user-domain-name {{ openstack_auth.user_domain_name }}
+-    --os-system-scope {{ openstack_auth.system_scope }}
++    --os-system-scope all
+     --os-region-name {{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert {{ openstack_cacert }}{% endif %}
+     baremetal node list --format json --column "Provisioning State"
+diff --git a/ansible/roles/keystone/tasks/register_identity_providers.yml b/ansible/roles/keystone/tasks/register_identity_providers.yml
+index 4695ab257..e0d5b2e23 100644
+--- a/ansible/roles/keystone/tasks/register_identity_providers.yml
++++ b/ansible/roles/keystone/tasks/register_identity_providers.yml
+@@ -7,7 +7,7 @@
+       --os-username={{ openstack_auth.username }}
+       --os-identity-api-version=3
+       --os-interface={{ openstack_interface }}
+-      --os-system-scope={{ openstack_auth.system_scope }}
++      --os-system-scope=all
+       --os-user-domain-name={{ openstack_auth.user_domain_name }}
+       --os-region-name={{ openstack_region_name }}
+       {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }} {% endif %}
+@@ -28,9 +28,9 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface={{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=keystone/tasks/register_identity_providers.yml
+     --os-region-name={{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }} {% endif %}
+     mapping delete {{ item }}
+@@ -64,7 +64,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface {{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+     --os-region-name={{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }} {% endif %}
+@@ -85,7 +85,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface={{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+     --os-region-name={{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }} {% endif %}
+@@ -106,7 +106,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface={{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+     --os-region-name={{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }} {% endif %}
+@@ -127,7 +127,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface={{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+     --os-region-name={ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }}{% endif %}
+@@ -147,7 +147,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface={{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+     --os-region-name={{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }}{% endif %}
+@@ -170,7 +170,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface {{ openstack_interface }}
+-    --os-system-scope {{ openstack_auth.system_scope }}
++    --os-system-scope all
+     --os-user-domain-name {{ openstack_auth.user_domain_name }}
+     --os-region-name {{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert {{ openstack_cacert }} {% endif %}
+@@ -192,7 +192,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface={{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+     --os-region-name={{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }}{% endif %}
+@@ -214,7 +214,7 @@
+     --os-username={{ openstack_auth.username }}
+     --os-identity-api-version=3
+     --os-interface={{ openstack_interface }}
+-    --os-system-scope={{ openstack_auth.system_scope }}
++    --os-system-scope=all
+     --os-user-domain-name={{ openstack_auth.user_domain_name }}
+     --os-region-name={{ openstack_region_name }}
+     {% if openstack_cacert != '' %}--os-cacert={{ openstack_cacert }}{% endif %}
+diff --git a/ansible/roles/nova-cell/tasks/wait_discover_computes.yml b/ansible/roles/nova-cell/tasks/wait_discover_computes.yml
+index 640138bfe..6a0b4b738 100644
+--- a/ansible/roles/nova-cell/tasks/wait_discover_computes.yml
++++ b/ansible/roles/nova-cell/tasks/wait_discover_computes.yml
+@@ -15,7 +15,7 @@
+         --os-password {{ openstack_auth.password }}
+         --os-identity-api-version 3
+         --os-user-domain-name {{ openstack_auth.user_domain_name }}
+-        --os-system-scope {{ openstack_auth.system_scope }}
++        --os-system-scope all
+         --os-region-name {{ openstack_region_name }}
+         {% if openstack_cacert != '' %}--os-cacert {{ openstack_cacert }}{% endif %}
+         compute service list --format json --column Host --service nova-compute


### PR DESCRIPTION
This replaces openstack_auth.system_scope with all (the default value of openstack_auth.system_scope) everywhere in prepartion of the new defaults in 2023.1.