### PR TITLE
Add kolla-rabbitmq-ng play

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,12 +1,13 @@
 ---
 exclude_paths:
   - .github/
-  - files/playbooks/2023.1/kolla-mariadb.yml    # exclude playbooks imported from the kolla-ansible upstream
-  - files/playbooks/2023.1/kolla-mariadb-ng.yml # exclude playbooks imported from the kolla-ansible upstream
-  - files/playbooks/2023.1/kolla-rabbitmq.yml   # exclude playbooks imported from the kolla-ansible upstream
-  - files/playbooks/kolla-loadbalancer-*.yml    # exclude playbooks imported from the kolla-ansible upstream
-  - files/playbooks/kolla-testbed-identity.yml  # excluded until we find a way to mock playbooks
-  - files/playbooks/kolla-testbed.yml           # excluded until we find a way to mock playbooks
+  - files/playbooks/2023.1/kolla-mariadb.yml     # exclude playbooks imported from the kolla-ansible upstream
+  - files/playbooks/2023.1/kolla-mariadb-ng.yml  # exclude playbooks imported from the kolla-ansible upstream
+  - files/playbooks/2023.1/kolla-rabbitmq.yml    # exclude playbooks imported from the kolla-ansible upstream
+  - files/playbooks/2023.1/kolla-rabbitmq-ng.yml # exclude playbooks imported from the kolla-ansible upstream
+  - files/playbooks/kolla-loadbalancer-*.yml     # exclude playbooks imported from the kolla-ansible upstream
+  - files/playbooks/kolla-testbed-identity.yml   # excluded until we find a way to mock playbooks
+  - files/playbooks/kolla-testbed.yml            # excluded until we find a way to mock playbooks
 use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/

--- a/files/playbooks/2023.1/kolla-mariadb-ng.yml
+++ b/files/playbooks/2023.1/kolla-mariadb-ng.yml
@@ -7,7 +7,7 @@
     - name: Inform the user about the following task
       debug:
         msg:
-          The task 'Check MariaDB service' fails if the Mariadb service has
+          The task 'Check MariaDB service' fails if the MariaDB service has
           not yet been deployed. This is fine.
       when:
         - kolla_action_ng == "deploy"

--- a/files/playbooks/2023.1/kolla-rabbitmq-ng.yml
+++ b/files/playbooks/2023.1/kolla-rabbitmq-ng.yml
@@ -1,0 +1,178 @@
+---
+- name: Set kolla_action_rabbitmq
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Inform the user about the following task
+      debug:
+        msg:
+          The task 'Check RabbitMQ service' fails if the RabbitMQ service has
+          not yet been deployed. This is fine.
+      when:
+        - kolla_action_ng == "deploy"
+
+    - name: Check RabbitMQ service
+      ansible.builtin.wait_for:
+        host: "{{ kolla_internal_vip_address }}"
+        port: "{{ rabbitmq_management_port }}"
+        connect_timeout: 1
+        timeout: 1
+        search_regex: "RabbitMQ Management"
+      register: check_rabbitmq_management_port
+      ignore_errors: true
+      when:
+        - kolla_action_ng == "deploy"
+
+    - name: Set kolla_action_rabbitmq = upgrade if RabbitMQ is already running
+      ansible.builtin.set_fact:
+        kolla_action_rabbitmq: upgrade
+      when:
+        - kolla_action_ng == "deploy"
+        - check_rabbitmq_management_port is success
+
+    - name: Set kolla_action_rabbitmq = kolla_action_ng
+      ansible.builtin.set_fact:
+        kolla_action_rabbitmq: "{{ kolla_action_ng }}"
+      when:
+        - kolla_action_ng == "deploy" and check_rabbitmq_management_port is not success
+        - kolla_action_ng != "deploy"
+
+- name: Group hosts based on configuration
+  hosts:
+    - rabbitmq
+    - outward-rabbitmq
+  gather_facts: false
+  tasks:
+    - name: Group hosts based on Kolla action
+      group_by:
+          key: kolla_action_{{ hostvars['localhost']['kolla_action_rabbitmq'] }}
+      changed_when: false
+
+    - name: Group hosts based on enabled services
+      group_by:
+          key: '{{ item }}'
+      changed_when: false
+      with_items: enable_rabbitmq_{{ enable_rabbitmq | bool }}
+  tags: always
+
+# For RabbitMQ we need to be careful about restarting services, to avoid losing quorum.
+- name: Apply role rabbitmq
+  gather_facts: false
+  hosts:
+    - rabbitmq
+    - '&enable_rabbitmq_True'
+  tags:
+    - rabbitmq
+  tasks:
+    - import_role:
+        name: rabbitmq
+      vars:
+        role_rabbitmq_cluster_cookie: '{{ rabbitmq_cluster_cookie }}'
+        role_rabbitmq_cluster_port: '{{ rabbitmq_cluster_port }}'
+        role_rabbitmq_epmd_port: '{{ rabbitmq_epmd_port }}'
+        role_rabbitmq_groups: rabbitmq
+        role_rabbitmq_management_port: '{{ rabbitmq_management_port }}'
+        role_rabbitmq_monitoring_password: '{{ rabbitmq_monitoring_password }}'
+        role_rabbitmq_monitoring_user: '{{ rabbitmq_monitoring_user }}'
+        role_rabbitmq_password: '{{ rabbitmq_password }}'
+        role_rabbitmq_port: '{{ rabbitmq_port }}'
+        role_rabbitmq_prometheus_port: '{{ rabbitmq_prometheus_port }}'
+        role_rabbitmq_user: '{{ rabbitmq_user }}'
+        kolla_action: "{{ hostvars['localhost']['kolla_action_rabbitmq'] }}"
+
+- name: Restart rabbitmq services
+  gather_facts: false
+  hosts:
+    - rabbitmq_restart
+    - '&enable_rabbitmq_True'
+  # Restart in batches
+  serial: "33%"
+  tags:
+    - rabbitmq
+  tasks:
+    - import_role:
+        name: rabbitmq
+        tasks_from: restart_services.yml
+      vars:
+        role_rabbitmq_cluster_cookie: '{{ rabbitmq_cluster_cookie }}'
+        role_rabbitmq_groups: rabbitmq
+        kolla_action: "{{ hostvars['localhost']['kolla_action_rabbitmq'] }}"
+
+- name: Apply rabbitmq post-configuration
+  gather_facts: false
+  hosts:
+    - rabbitmq
+    - '&enable_rabbitmq_True'
+  tags:
+    - rabbitmq
+  tasks:
+    - name: Include rabbitmq post-deploy.yml
+      include_role:
+        name: rabbitmq
+        tasks_from: post-deploy.yml
+      when: kolla_action in ['deploy', 'reconfigure']
+      vars:
+        role_rabbitmq_cluster_cookie: '{{ rabbitmq_cluster_cookie }}'
+        role_rabbitmq_groups: rabbitmq
+        kolla_action: "{{ hostvars['localhost']['kolla_action_rabbitmq'] }}"
+
+- name: Apply role rabbitmq (outward)
+  gather_facts: false
+  hosts:
+    - outward-rabbitmq
+    - '&enable_outward_rabbitmq_True'
+  tags:
+    - rabbitmq
+  tasks:
+    - import_role:
+        name: rabbitmq
+      vars:
+        project_name: outward_rabbitmq
+        role_rabbitmq_cluster_cookie: '{{ outward_rabbitmq_cluster_cookie }}'
+        role_rabbitmq_cluster_port: '{{ outward_rabbitmq_cluster_port }}'
+        role_rabbitmq_epmd_port: '{{ outward_rabbitmq_epmd_port }}'
+        role_rabbitmq_groups: outward-rabbitmq
+        role_rabbitmq_management_port: '{{ outward_rabbitmq_management_port }}'
+        role_rabbitmq_password: '{{ outward_rabbitmq_password }}'
+        role_rabbitmq_port: '{{ outward_rabbitmq_port }}'
+        role_rabbitmq_prometheus_port: '{{ outward_rabbitmq_prometheus_port }}'
+        role_rabbitmq_user: '{{ outward_rabbitmq_user }}'
+        kolla_action: "{{ hostvars['localhost']['kolla_action_rabbitmq'] }}"
+
+- name: Restart rabbitmq (outward) services
+  gather_facts: false
+  hosts:
+    - outward_rabbitmq_restart
+    - '&enable_outward_rabbitmq_True'
+  # Restart in batches
+  serial: "33%"
+  tags:
+    - rabbitmq
+  tasks:
+    - import_role:
+        name: rabbitmq
+        tasks_from: restart_services.yml
+      vars:
+        project_name: outward_rabbitmq
+        role_rabbitmq_cluster_cookie: '{{ outward_rabbitmq_cluster_cookie }}'
+        role_rabbitmq_groups: outward-rabbitmq
+        kolla_action: "{{ hostvars['localhost']['kolla_action_rabbitmq'] }}"
+
+- name: Apply rabbitmq (outward) post-configuration
+  gather_facts: false
+  hosts:
+    - outward-rabbitmq
+    - '&enable_outward_rabbitmq_True'
+  tags:
+    - rabbitmq
+  tasks:
+    - name: Include rabbitmq (outward) post-deploy.yml
+      include_role:
+        name: rabbitmq
+      when: kolla_action in ['deploy', 'reconfigure']
+      vars:
+        project_name: outward_rabbitmq
+        role_rabbitmq_cluster_cookie: '{{ outward_rabbitmq_cluster_cookie }}'
+        role_rabbitmq_groups: outward-rabbitmq
+        kolla_action: "{{ hostvars['localhost']['kolla_action_rabbitmq'] }}"


### PR DESCRIPTION
The play checks in advance whether the RabbitMQ service is already running when the action is deployed. If the RabbitMQ service is already running, the action is changed to upgrade.