### PR TITLE
Install osism.commons collection

### DIFF
--- a/files/requirements.yml
+++ b/files/requirements.yml
@@ -30,3 +30,5 @@ collections:
     source: https://galaxy.ansible.com
   - name: community.rabbitmq
     source: https://galaxy.ansible.com
+  - name: osism.commons
+    source: https://galaxy.ansible.com


### PR DESCRIPTION
Required to be able to use the still_alive callback plugin.