### PR TITLE
Add ceph_keyring parameters to the 2023.1/zed overlays

### DIFF
--- a/overlays/2023.1/kolla-ansible.yml
+++ b/overlays/2023.1/kolla-ansible.yml
@@ -1,0 +1,3 @@
+---
+ceph_cinder_keyring: "ceph.client.cinder.keyring"
+ceph_nova_keyring: "ceph.client.nova.keyring"

--- a/overlays/zed/kolla-ansible.yml
+++ b/overlays/zed/kolla-ansible.yml
@@ -1,0 +1,3 @@
+---
+ceph_cinder_keyring: "ceph.client.cinder.keyring"
+ceph_nova_keyring: "ceph.client.nova.keyring"


### PR DESCRIPTION
This should avoid conflicts with the 2023.2 release.