### PR TITLE
zuul: set timeout = 3600 for the zed jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -48,6 +48,7 @@
 - job:
     name: container-image-kolla-ansible-build-zed
     parent: container-image-kolla-ansible-build
+    timeout: 3600
     vars:
       version_openstack: zed
       push_image: false


### PR DESCRIPTION
There is some nasty bug in Ansible that we use for Zed that sometimes takes forever to install collections from Ansible Galaxy. As we will soon be removing Zed, debugging is not worth it. With a timeout of 1 hour, the builds should run without fail.