### PR TITLE
2023.2: add keystone service role

### DIFF
--- a/patches/2023.2/keystone-add-service-role.patch
+++ b/patches/2023.2/keystone-add-service-role.patch
@@ -1,0 +1,73 @@
+From 01c359665b53ef51837bd2bde649f969e0223d7f Mon Sep 17 00:00:00 2001
+From: Bartosz Bezak <bartosz@stackhpc.com>
+Date: Wed, 14 Feb 2024 15:59:01 +0100
+Subject: [PATCH] Keystone: Add service role
+
+Keystone is creating service in bootstrap since Bobcat [1].
+Service role is needed for SLURP to work from Antelope.
+This role is also needed in Antelope and Zed for Cinder for
+proper service token support. [2]
+
+[1] https://review.opendev.org/c/openstack/keystone/+/863420
+[2] https://bugs.launchpad.net/kolla-ansible/+bug/2049762
+
+Related-Bug: #2049762
+Change-Id: I7685904ef92b60793545dab4b998f88ad48f2e8f
+---
+
+diff --git a/ansible/roles/keystone/defaults/main.yml b/ansible/roles/keystone/defaults/main.yml
+index 94de04d..1765325 100644
+--- a/ansible/roles/keystone/defaults/main.yml
++++ b/ansible/roles/keystone/defaults/main.yml
+@@ -216,6 +216,9 @@
+     description: "Openstack Identity Service"
+     endpoints: "{{ keystone_service_endpoints + ([keystone_service_admin_endpoint] if kolla_action == 'upgrade' or keystone_create_admin_endpoint | bool else []) }}"
+ 
++keystone_ks_roles:
++  - service
++
+ ####################
+ # TLS
+ ####################
+diff --git a/ansible/roles/keystone/tasks/register.yml b/ansible/roles/keystone/tasks/register.yml
+index d3b15fe..28fc1a6 100644
+--- a/ansible/roles/keystone/tasks/register.yml
++++ b/ansible/roles/keystone/tasks/register.yml
+@@ -16,6 +16,7 @@
+   vars:
+     service_ks_register_auth: "{{ openstack_keystone_auth }}"
+     service_ks_register_services: "{{ keystone_ks_services }}"
++    service_ks_register_roles: "{{ keystone_ks_roles }}"
+   run_once: True
+ 
+ - name: Creating default user role
+diff --git a/ansible/roles/keystone/tasks/upgrade.yml b/ansible/roles/keystone/tasks/upgrade.yml
+index bbe2ca933..c1434c502 100644
+--- a/ansible/roles/keystone/tasks/upgrade.yml
++++ b/ansible/roles/keystone/tasks/upgrade.yml
+@@ -48,3 +48,10 @@
+   run_once: True
+   when:
+     - not use_preconfigured_databases | bool
++
++- import_role:
++    name: service-ks-register
++  vars:
++    service_ks_register_auth: "{{ openstack_keystone_auth }}"
++    service_ks_register_roles: "{{ keystone_ks_roles }}"
++  run_once: True
+diff --git a/releasenotes/notes/keystone-service-role-bbffc258538b07c1.yaml b/releasenotes/notes/keystone-service-role-bbffc258538b07c1.yaml
+new file mode 100644
+index 0000000..9cb4e4c
+--- /dev/null
++++ b/releasenotes/notes/keystone-service-role-bbffc258538b07c1.yaml
+@@ -0,0 +1,9 @@
++---
++fixes:
++  - |
++    Add Keystone Service role. Keystone is creating service
++    in bootstrap since Bobcat. Service role is needed for
++    SLURP to work from Antelope. This role is also needed
++    in Antelope and Zed for Cinder for proper service token
++    support.
++    `LP#2049762 <https://launchpad.net/bugs/2049762>`__


### PR DESCRIPTION
Required to ensure that the service role is added on old environments.

Related to osism/issues#907