### PR TITLE
Add patches for kolla-operations deployment

### DIFF
--- a/patches/2023.1/kolla-operations.patch
+++ b/patches/2023.1/kolla-operations.patch
@@ -1,0 +1,279 @@
+diff --git a/ansible/roles/grafana/defaults/main.yml b/ansible/roles/grafana/defaults/main.yml
+index ca7d78493..1ee2e7345 100644
+--- a/ansible/roles/grafana/defaults/main.yml
++++ b/ansible/roles/grafana/defaults/main.yml
+@@ -87,6 +87,22 @@ grafana_extra_volumes: "{{ default_extra_volumes }}"
+ grafana_start_first_node_delay: 10
+ grafana_start_first_node_retries: 12
+ 
++grafana_custom_extra_config_paths:
++  - "{{ node_custom_config }}/grafana/"
++
++grafana_prometheus_config_paths:
++    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/prometheus.yaml"
++    - "{{ node_custom_config }}/grafana/prometheus.yaml"
++    - "prometheus.yaml.j2"
++
++grafana_provisioning_config_paths:
++    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/provisioning.yaml"
++    - "{{ node_custom_config }}/grafana/provisioning.yaml"
++    - "provisioning.yaml.j2"
++
++grafana_custom_dashboards_paths:
++  - "{{ node_custom_config }}/grafana/dashboards"
++
+ ############
+ # Prometheus
+ ############
+diff --git a/ansible/roles/grafana/tasks/config.yml b/ansible/roles/grafana/tasks/config.yml
+index cc12d874a..2dc0b13a2 100644
+--- a/ansible/roles/grafana/tasks/config.yml
++++ b/ansible/roles/grafana/tasks/config.yml
+@@ -14,7 +14,10 @@
+ 
+ - name: Check if extra configuration file exists
+   find:
+-    path: "{{ node_custom_config }}/grafana/"
++    paths: "{{ grafana_custom_extra_config_paths }}"
++    excludes:
++      - "prometheus.yaml"
++      - "provisioning.yaml"
+   delegate_to: localhost
+   changed_when: False
+   run_once: True
+@@ -63,25 +66,7 @@
+     mode: "0660"
+   when:
+     - item is defined
+-  with_items:
+-    - "{{ check_extra_conf_grafana.files }}"
+-  notify:
+-    - Restart grafana container
+-
+-- name: Check if custom grafana home dashboard exists
+-  stat:
+-    path: "{{ node_custom_config }}/grafana/grafana_home_dashboard.json"
+-  delegate_to: localhost
+-  register: grafana_custom_dashboard_file
+-  run_once: True
+-
+-- name: Copying over grafana home dashboard if exists
+-  become: true
+-  template:
+-    src: "{{ node_custom_config }}/grafana/grafana_home_dashboard.json"
+-    dest: "{{ node_config_directory }}/grafana/grafana_home_dashboard.json"
+-    mode: "0660"
+-  when: grafana_custom_dashboard_file.stat.exists
++  with_items: "{{ dict( check_extra_conf_grafana.files | map(attribute='path') | map('basename') | zip(check_extra_conf_grafana.files) ) | dict2items | map(attribute='value') }}"
+   notify:
+     - Restart grafana container
+ 
+@@ -97,10 +82,7 @@
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
+     - enable_prometheus | bool
+-  with_first_found:
+-    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/prometheus.yaml"
+-    - "{{ node_custom_config }}/grafana/prometheus.yaml"
+-    - "prometheus.yaml.j2"
++  with_first_found: "{{ grafana_prometheus_config_paths }}"
+   notify:
+     - Restart grafana container
+ 
+@@ -115,43 +97,62 @@
+   when:
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
+-  with_first_found:
+-    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/provisioning.yaml"
+-    - "{{ node_custom_config }}/grafana/provisioning.yaml"
+-    - "{{ role_path }}/templates/provisioning.yaml.j2"
++  with_first_found: "{{ grafana_provisioning_config_paths }}"
+   notify:
+     - Restart grafana container
+ 
+-- name: Check if the folder for custom grafana dashboards exists
+-  stat:
+-    path: "{{ node_custom_config }}/grafana/dashboards"
++- name: Find custom grafana dashboards
++  find:
++    paths: "{{ grafana_custom_dashboards_paths }}"
++    recurse: true
+   delegate_to: localhost
+-  register: grafana_custom_dashboards_folder
++  register: grafana_custom_dashboards
+   run_once: True
+ 
+-- name: Remove templated Grafana dashboards
++- name: Find templated grafana dashboards
+   become: true
+   vars:
+     service: "{{ grafana_services['grafana'] }}"
++  find:
++    path: "{{ node_config_directory }}/grafana/dashboards"
++    recurse: true
++    file_type: any
++  register: grafana_templated_dashboards
++  when:
++    - inventory_hostname in groups[service.group]
++    - service.enabled | bool
++
++- name: Prune templated Grafana dashboards
++  become: true
++  vars:
++    service: "{{ grafana_services['grafana'] }}"
++    dashboards_templated_path_regex: "^{{ node_config_directory | regex_escape }}/grafana/dashboards/(.*)$"
++    dashboards_config_paths_regex: "^({{ grafana_custom_dashboards_paths | map('regex_escape') | join('|') }})/(.*)$"
++    dashboards_templated_relative_path: "{{ grafana_templated_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_templated_path_regex, '\\1') }}"
++    dashboards_config_relative_path: "{{ grafana_custom_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_config_paths_regex, '\\2') | unique }}"
+   file:
+     state: absent
+-    path: "{{ node_config_directory }}/grafana/dashboards/"
++    path: "{{ node_config_directory }}/grafana/dashboards/{{ item }}"
+   when:
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
++  with_items: "{{ dashboards_templated_relative_path | reject('in', dashboards_config_relative_path) | reject('in', dashboards_config_relative_path | map('dirname')) }}"
++  notify:
++    - Restart grafana container
+ 
+ - name: Copying over custom dashboards
+   vars:
+     service: "{{ grafana_services['grafana'] }}"
++    dashboards_config_paths_regex: "^({{ grafana_custom_dashboards_paths | map('regex_escape') | join('|') }})/(.*)$"
++    dashboards_config_relative_path: "{{ grafana_custom_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_config_paths_regex,'\\2') }}"
+   copy:
+-    src: "{{ node_custom_config }}/grafana/dashboards"
+-    dest: "{{ node_config_directory }}/grafana/"
++    src: "{{ item.value.path }}"
++    dest: "{{ node_config_directory }}/grafana/dashboards/{{ item.key | dirname }}/"
+     mode: "0660"
+   become: true
+   when:
+-    - grafana_custom_dashboards_folder.stat.exists
+-    - grafana_custom_dashboards_folder.stat.isdir
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
++  with_items: "{{ dict( dashboards_config_relative_path | zip(grafana_custom_dashboards.files) ) | dict2items }}"
+   notify:
+     - Restart grafana container
+diff --git a/ansible/roles/grafana/tasks/post_config.yml b/ansible/roles/grafana/tasks/post_config.yml
+index a59a689ce..ad57da48e 100644
+--- a/ansible/roles/grafana/tasks/post_config.yml
++++ b/ansible/roles/grafana/tasks/post_config.yml
+@@ -50,4 +50,4 @@
+   register: grafana_response
+   changed_when: grafana_response.status == 200
+   run_once: true
+-  when: grafana_custom_dashboard_file.stat.exists
++  when: "'grafana_home_dashboard.json' in check_extra_conf_grafana.files | map(attribute='path') | map('basename')"
+diff --git a/ansible/roles/grafana/templates/grafana.json.j2 b/ansible/roles/grafana/templates/grafana.json.j2
+index fcc3cc34b..fd113812a 100644
+--- a/ansible/roles/grafana/templates/grafana.json.j2
++++ b/ansible/roles/grafana/templates/grafana.json.j2
+@@ -7,21 +7,20 @@
+             "owner": "grafana",
+             "perm": "0600"
+         },
+-{% if check_extra_conf_grafana is defined %}{% if check_extra_conf_grafana.matched > 0 %}{% for plugin in check_extra_conf_grafana.files %}
++{% for extra_conf in check_extra_conf_grafana.files | map(attribute='path') | map('basename') | unique %}
+         {
+-            "source": "{{ container_config_directory }}/{{ plugin.path | basename }}",
+-            "dest": "/etc/grafana/{{ plugin.path | basename }}",
+-            "owner": "grafana",
+-            "perm": "0600"
+-        },
+-{% endfor %}{% endif %}{% endif %}
+-        {
+-            "source": "{{ container_config_directory }}/grafana_home_dashboard.json",
++            "source": "{{ container_config_directory }}/{{ extra_conf }}",
++{%   if extra_conf  == 'grafana_home_dashboard.json' %}
+             "dest": "/usr/share/grafana/public/dashboards/home.json",
+             "owner": "root",
+-            "perm": "0644",
+-            "optional": true
++            "perm": "0644"
++{%   else %}
++            "dest": "/etc/grafana/{{ extra_conf }}",
++            "owner": "grafana",
++            "perm": "0600"
++{%   endif %}
+         },
++{% endfor %}
+         {
+             "source": "{{ container_config_directory }}/prometheus.yaml",
+             "dest": "/etc/grafana/provisioning/datasources/prometheus.yaml",
+diff --git a/ansible/roles/prometheus/defaults/main.yml b/ansible/roles/prometheus/defaults/main.yml
+index a72d86783..46fb46ca0 100644
+--- a/ansible/roles/prometheus/defaults/main.yml
++++ b/ansible/roles/prometheus/defaults/main.yml
+@@ -131,6 +131,12 @@ prometheus_services:
+ ####################
+ # Prometheus Server
+ ####################
++prometheus_custom_alert_paths:
++  - "{{ node_custom_config }}/prometheus/"
++
++prometheus_common_config_overrides_paths:
++  - "{{ node_custom_config }}/prometheus/prometheus.yml.d"
++
+ prometheus_external_labels:
+ #  <labelname>: <labelvalue>
+ 
+diff --git a/ansible/roles/prometheus/tasks/config.yml b/ansible/roles/prometheus/tasks/config.yml
+index f55f6b5ba..bf83be9d7 100644
+--- a/ansible/roles/prometheus/tasks/config.yml
++++ b/ansible/roles/prometheus/tasks/config.yml
+@@ -31,7 +31,7 @@
+ 
+ - name: Find custom prometheus alert rules files
+   find:
+-    path: "{{ node_custom_config }}/prometheus/"
++    paths: "{{ prometheus_custom_alert_paths }}"
+     pattern: "*.rules"
+   run_once: True
+   delegate_to: localhost
+@@ -51,15 +51,14 @@
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool and enable_prometheus_alertmanager | bool
+     - prometheus_alert_rules is defined and prometheus_alert_rules.files | length > 0
+-  with_items: "{{ prometheus_alert_rules.files }}"
++  with_items: "{{ dict( prometheus_alert_rules.files | map(attribute='path') | map('basename') | zip(prometheus_alert_rules.files) ) | dict2items | map(attribute='value') }}"
+   notify:
+     - Restart prometheus-server container
+ 
+ - name: Find prometheus common config overrides
+   find:
+     # NOTE(wszumski): Non-existent paths don't produce a failure
+-    paths:
+-      - "{{ node_custom_config }}/prometheus/prometheus.yml.d"
++    paths: "{{ prometheus_common_config_overrides_paths }}"
+     patterns: "*.yml"
+   delegate_to: localhost
+   register: prometheus_common_config_overrides_result
+@@ -80,8 +79,9 @@
+   become: true
+   vars:
+     service: "{{ prometheus_services['prometheus-server'] }}"
+-    common_overrides: "{{ prometheus_common_config_overrides_result.files | map(attribute='path') | list }}"
++    _common_overrides: "{{ prometheus_common_config_overrides_result.files | map(attribute='path') | list }}"
+     host_overrides: "{{ prometheus_host_config_overrides_result.files | map(attribute='path') | list }}"
++    common_overrides: "{{ dict( _common_overrides | map('basename') | zip(_common_overrides) ) | dict2items | sort(attribute='key') | map(attribute='value') | list }}"
+   merge_yaml:
+     sources: "{{ [item] + common_overrides + host_overrides }}"
+     dest: "{{ node_config_directory }}/prometheus-server/prometheus.yml"
+diff --git a/ansible/roles/prometheus/templates/prometheus.yml.j2 b/ansible/roles/prometheus/templates/prometheus.yml.j2
+index f0ff6c846..d45a6284b 100644
+--- a/ansible/roles/prometheus/templates/prometheus.yml.j2
++++ b/ansible/roles/prometheus/templates/prometheus.yml.j2
+@@ -11,8 +11,8 @@ global:
+ 
+ {% if prometheus_alert_rules.files is defined and prometheus_alert_rules.files | length  > 0 %}
+ rule_files:
+-{% for rule in prometheus_alert_rules.files %}
+-  - "/etc/prometheus/{{ rule.path | basename }}"
++{% for rule in prometheus_alert_rules.files | map(attribute='path') | map('basename') | unique %}
++  - "/etc/prometheus/{{ rule }}"
+ {% endfor %}
+ {% endif %}
+ 

--- a/patches/2023.2/kolla-operations.patch
+++ b/patches/2023.2/kolla-operations.patch
@@ -1,0 +1,279 @@
+diff --git a/ansible/roles/grafana/defaults/main.yml b/ansible/roles/grafana/defaults/main.yml
+index 63cd0e5e9..f60ce9008 100644
+--- a/ansible/roles/grafana/defaults/main.yml
++++ b/ansible/roles/grafana/defaults/main.yml
+@@ -90,6 +90,22 @@ grafana_extra_volumes: "{{ default_extra_volumes }}"
+ grafana_start_first_node_delay: 10
+ grafana_start_first_node_retries: 12
+ 
++grafana_custom_extra_config_paths:
++  - "{{ node_custom_config }}/grafana/"
++
++grafana_prometheus_config_paths:
++    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/prometheus.yaml"
++    - "{{ node_custom_config }}/grafana/prometheus.yaml"
++    - "prometheus.yaml.j2"
++
++grafana_provisioning_config_paths:
++    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/provisioning.yaml"
++    - "{{ node_custom_config }}/grafana/provisioning.yaml"
++    - "provisioning.yaml.j2"
++
++grafana_custom_dashboards_paths:
++  - "{{ node_custom_config }}/grafana/dashboards"
++
+ ############
+ # Prometheus
+ ############
+diff --git a/ansible/roles/grafana/tasks/config.yml b/ansible/roles/grafana/tasks/config.yml
+index cc12d874a..2dc0b13a2 100644
+--- a/ansible/roles/grafana/tasks/config.yml
++++ b/ansible/roles/grafana/tasks/config.yml
+@@ -14,7 +14,10 @@
+ 
+ - name: Check if extra configuration file exists
+   find:
+-    path: "{{ node_custom_config }}/grafana/"
++    paths: "{{ grafana_custom_extra_config_paths }}"
++    excludes:
++      - "prometheus.yaml"
++      - "provisioning.yaml"
+   delegate_to: localhost
+   changed_when: False
+   run_once: True
+@@ -63,25 +66,7 @@
+     mode: "0660"
+   when:
+     - item is defined
+-  with_items:
+-    - "{{ check_extra_conf_grafana.files }}"
+-  notify:
+-    - Restart grafana container
+-
+-- name: Check if custom grafana home dashboard exists
+-  stat:
+-    path: "{{ node_custom_config }}/grafana/grafana_home_dashboard.json"
+-  delegate_to: localhost
+-  register: grafana_custom_dashboard_file
+-  run_once: True
+-
+-- name: Copying over grafana home dashboard if exists
+-  become: true
+-  template:
+-    src: "{{ node_custom_config }}/grafana/grafana_home_dashboard.json"
+-    dest: "{{ node_config_directory }}/grafana/grafana_home_dashboard.json"
+-    mode: "0660"
+-  when: grafana_custom_dashboard_file.stat.exists
++  with_items: "{{ dict( check_extra_conf_grafana.files | map(attribute='path') | map('basename') | zip(check_extra_conf_grafana.files) ) | dict2items | map(attribute='value') }}"
+   notify:
+     - Restart grafana container
+ 
+@@ -97,10 +82,7 @@
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
+     - enable_prometheus | bool
+-  with_first_found:
+-    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/prometheus.yaml"
+-    - "{{ node_custom_config }}/grafana/prometheus.yaml"
+-    - "prometheus.yaml.j2"
++  with_first_found: "{{ grafana_prometheus_config_paths }}"
+   notify:
+     - Restart grafana container
+ 
+@@ -115,43 +97,62 @@
+   when:
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
+-  with_first_found:
+-    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/provisioning.yaml"
+-    - "{{ node_custom_config }}/grafana/provisioning.yaml"
+-    - "{{ role_path }}/templates/provisioning.yaml.j2"
++  with_first_found: "{{ grafana_provisioning_config_paths }}"
+   notify:
+     - Restart grafana container
+ 
+-- name: Check if the folder for custom grafana dashboards exists
+-  stat:
+-    path: "{{ node_custom_config }}/grafana/dashboards"
++- name: Find custom grafana dashboards
++  find:
++    paths: "{{ grafana_custom_dashboards_paths }}"
++    recurse: true
+   delegate_to: localhost
+-  register: grafana_custom_dashboards_folder
++  register: grafana_custom_dashboards
+   run_once: True
+ 
+-- name: Remove templated Grafana dashboards
++- name: Find templated grafana dashboards
+   become: true
+   vars:
+     service: "{{ grafana_services['grafana'] }}"
++  find:
++    path: "{{ node_config_directory }}/grafana/dashboards"
++    recurse: true
++    file_type: any
++  register: grafana_templated_dashboards
++  when:
++    - inventory_hostname in groups[service.group]
++    - service.enabled | bool
++
++- name: Prune templated Grafana dashboards
++  become: true
++  vars:
++    service: "{{ grafana_services['grafana'] }}"
++    dashboards_templated_path_regex: "^{{ node_config_directory | regex_escape }}/grafana/dashboards/(.*)$"
++    dashboards_config_paths_regex: "^({{ grafana_custom_dashboards_paths | map('regex_escape') | join('|') }})/(.*)$"
++    dashboards_templated_relative_path: "{{ grafana_templated_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_templated_path_regex, '\\1') }}"
++    dashboards_config_relative_path: "{{ grafana_custom_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_config_paths_regex, '\\2') | unique }}"
+   file:
+     state: absent
+-    path: "{{ node_config_directory }}/grafana/dashboards/"
++    path: "{{ node_config_directory }}/grafana/dashboards/{{ item }}"
+   when:
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
++  with_items: "{{ dashboards_templated_relative_path | reject('in', dashboards_config_relative_path) | reject('in', dashboards_config_relative_path | map('dirname')) }}"
++  notify:
++    - Restart grafana container
+ 
+ - name: Copying over custom dashboards
+   vars:
+     service: "{{ grafana_services['grafana'] }}"
++    dashboards_config_paths_regex: "^({{ grafana_custom_dashboards_paths | map('regex_escape') | join('|') }})/(.*)$"
++    dashboards_config_relative_path: "{{ grafana_custom_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_config_paths_regex,'\\2') }}"
+   copy:
+-    src: "{{ node_custom_config }}/grafana/dashboards"
+-    dest: "{{ node_config_directory }}/grafana/"
++    src: "{{ item.value.path }}"
++    dest: "{{ node_config_directory }}/grafana/dashboards/{{ item.key | dirname }}/"
+     mode: "0660"
+   become: true
+   when:
+-    - grafana_custom_dashboards_folder.stat.exists
+-    - grafana_custom_dashboards_folder.stat.isdir
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
++  with_items: "{{ dict( dashboards_config_relative_path | zip(grafana_custom_dashboards.files) ) | dict2items }}"
+   notify:
+     - Restart grafana container
+diff --git a/ansible/roles/grafana/tasks/post_config.yml b/ansible/roles/grafana/tasks/post_config.yml
+index a59a689ce..ad57da48e 100644
+--- a/ansible/roles/grafana/tasks/post_config.yml
++++ b/ansible/roles/grafana/tasks/post_config.yml
+@@ -50,4 +50,4 @@
+   register: grafana_response
+   changed_when: grafana_response.status == 200
+   run_once: true
+-  when: grafana_custom_dashboard_file.stat.exists
++  when: "'grafana_home_dashboard.json' in check_extra_conf_grafana.files | map(attribute='path') | map('basename')"
+diff --git a/ansible/roles/grafana/templates/grafana.json.j2 b/ansible/roles/grafana/templates/grafana.json.j2
+index fcc3cc34b..fd113812a 100644
+--- a/ansible/roles/grafana/templates/grafana.json.j2
++++ b/ansible/roles/grafana/templates/grafana.json.j2
+@@ -7,21 +7,20 @@
+             "owner": "grafana",
+             "perm": "0600"
+         },
+-{% if check_extra_conf_grafana is defined %}{% if check_extra_conf_grafana.matched > 0 %}{% for plugin in check_extra_conf_grafana.files %}
++{% for extra_conf in check_extra_conf_grafana.files | map(attribute='path') | map('basename') | unique %}
+         {
+-            "source": "{{ container_config_directory }}/{{ plugin.path | basename }}",
+-            "dest": "/etc/grafana/{{ plugin.path | basename }}",
+-            "owner": "grafana",
+-            "perm": "0600"
+-        },
+-{% endfor %}{% endif %}{% endif %}
+-        {
+-            "source": "{{ container_config_directory }}/grafana_home_dashboard.json",
++            "source": "{{ container_config_directory }}/{{ extra_conf }}",
++{%   if extra_conf  == 'grafana_home_dashboard.json' %}
+             "dest": "/usr/share/grafana/public/dashboards/home.json",
+             "owner": "root",
+-            "perm": "0644",
+-            "optional": true
++            "perm": "0644"
++{%   else %}
++            "dest": "/etc/grafana/{{ extra_conf }}",
++            "owner": "grafana",
++            "perm": "0600"
++{%   endif %}
+         },
++{% endfor %}
+         {
+             "source": "{{ container_config_directory }}/prometheus.yaml",
+             "dest": "/etc/grafana/provisioning/datasources/prometheus.yaml",
+diff --git a/ansible/roles/prometheus/defaults/main.yml b/ansible/roles/prometheus/defaults/main.yml
+index f18256d44..0db938406 100644
+--- a/ansible/roles/prometheus/defaults/main.yml
++++ b/ansible/roles/prometheus/defaults/main.yml
+@@ -141,6 +141,12 @@ prometheus_services:
+ ####################
+ # Prometheus Server
+ ####################
++prometheus_custom_alert_paths:
++  - "{{ node_custom_config }}/prometheus/"
++
++prometheus_common_config_overrides_paths:
++  - "{{ node_custom_config }}/prometheus/prometheus.yml.d"
++
+ prometheus_external_labels:
+ #  <labelname>: <labelvalue>
+ 
+diff --git a/ansible/roles/prometheus/tasks/config.yml b/ansible/roles/prometheus/tasks/config.yml
+index 9ad3fa911..fb12d57b7 100644
+--- a/ansible/roles/prometheus/tasks/config.yml
++++ b/ansible/roles/prometheus/tasks/config.yml
+@@ -31,7 +31,7 @@
+ 
+ - name: Find custom prometheus alert rules files
+   find:
+-    path: "{{ node_custom_config }}/prometheus/"
++    paths: "{{ prometheus_custom_alert_paths }}"
+     pattern: "*.rules"
+   run_once: True
+   delegate_to: localhost
+@@ -51,15 +51,14 @@
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool and enable_prometheus_alertmanager | bool
+     - prometheus_alert_rules is defined and prometheus_alert_rules.files | length > 0
+-  with_items: "{{ prometheus_alert_rules.files }}"
++  with_items: "{{ dict( prometheus_alert_rules.files | map(attribute='path') | map('basename') | zip(prometheus_alert_rules.files) ) | dict2items | map(attribute='value') }}"
+   notify:
+     - Restart prometheus-server container
+ 
+ - name: Find prometheus common config overrides
+   find:
+     # NOTE(wszumski): Non-existent paths don't produce a failure
+-    paths:
+-      - "{{ node_custom_config }}/prometheus/prometheus.yml.d"
++    paths: "{{ prometheus_common_config_overrides_paths }}"
+     patterns: "*.yml"
+   delegate_to: localhost
+   register: prometheus_common_config_overrides_result
+@@ -80,8 +79,9 @@
+   become: true
+   vars:
+     service: "{{ prometheus_services['prometheus-server'] }}"
+-    common_overrides: "{{ prometheus_common_config_overrides_result.files | map(attribute='path') | list }}"
++    _common_overrides: "{{ prometheus_common_config_overrides_result.files | map(attribute='path') | list }}"
+     host_overrides: "{{ prometheus_host_config_overrides_result.files | map(attribute='path') | list }}"
++    common_overrides: "{{ dict( _common_overrides | map('basename') | zip(_common_overrides) ) | dict2items | sort(attribute='key') | map(attribute='value') | list }}"
+   merge_yaml:
+     sources: "{{ [item] + common_overrides + host_overrides }}"
+     dest: "{{ node_config_directory }}/prometheus-server/prometheus.yml"
+diff --git a/ansible/roles/prometheus/templates/prometheus.yml.j2 b/ansible/roles/prometheus/templates/prometheus.yml.j2
+index be4febed0..8864aa6ee 100644
+--- a/ansible/roles/prometheus/templates/prometheus.yml.j2
++++ b/ansible/roles/prometheus/templates/prometheus.yml.j2
+@@ -11,8 +11,8 @@ global:
+ 
+ {% if prometheus_alert_rules.files is defined and prometheus_alert_rules.files | length  > 0 %}
+ rule_files:
+-{% for rule in prometheus_alert_rules.files %}
+-  - "/etc/prometheus/{{ rule.path | basename }}"
++{% for rule in prometheus_alert_rules.files | map(attribute='path') | map('basename') | unique %}
++  - "/etc/prometheus/{{ rule }}"
+ {% endfor %}
+ {% endif %}
+ 

--- a/patches/2024.1/kolla-operations.patch
+++ b/patches/2024.1/kolla-operations.patch
@@ -1,0 +1,279 @@
+diff --git a/ansible/roles/grafana/defaults/main.yml b/ansible/roles/grafana/defaults/main.yml
+index eae1f03fb..a5d0d3d61 100644
+--- a/ansible/roles/grafana/defaults/main.yml
++++ b/ansible/roles/grafana/defaults/main.yml
+@@ -93,6 +93,22 @@ grafana_start_first_node_retries: 12
+ # TODO(dawudm): make this True in the D release
+ grafana_remove_old_volume: false
+ 
++grafana_custom_extra_config_paths:
++  - "{{ node_custom_config }}/grafana/"
++
++grafana_prometheus_config_paths:
++    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/prometheus.yaml"
++    - "{{ node_custom_config }}/grafana/prometheus.yaml"
++    - "prometheus.yaml.j2"
++
++grafana_provisioning_config_paths:
++    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/provisioning.yaml"
++    - "{{ node_custom_config }}/grafana/provisioning.yaml"
++    - "provisioning.yaml.j2"
++
++grafana_custom_dashboards_paths:
++  - "{{ node_custom_config }}/grafana/dashboards"
++
+ ############
+ # Prometheus
+ ############
+diff --git a/ansible/roles/grafana/tasks/config.yml b/ansible/roles/grafana/tasks/config.yml
+index cc12d874a..2dc0b13a2 100644
+--- a/ansible/roles/grafana/tasks/config.yml
++++ b/ansible/roles/grafana/tasks/config.yml
+@@ -14,7 +14,10 @@
+ 
+ - name: Check if extra configuration file exists
+   find:
+-    path: "{{ node_custom_config }}/grafana/"
++    paths: "{{ grafana_custom_extra_config_paths }}"
++    excludes:
++      - "prometheus.yaml"
++      - "provisioning.yaml"
+   delegate_to: localhost
+   changed_when: False
+   run_once: True
+@@ -63,25 +66,7 @@
+     mode: "0660"
+   when:
+     - item is defined
+-  with_items:
+-    - "{{ check_extra_conf_grafana.files }}"
+-  notify:
+-    - Restart grafana container
+-
+-- name: Check if custom grafana home dashboard exists
+-  stat:
+-    path: "{{ node_custom_config }}/grafana/grafana_home_dashboard.json"
+-  delegate_to: localhost
+-  register: grafana_custom_dashboard_file
+-  run_once: True
+-
+-- name: Copying over grafana home dashboard if exists
+-  become: true
+-  template:
+-    src: "{{ node_custom_config }}/grafana/grafana_home_dashboard.json"
+-    dest: "{{ node_config_directory }}/grafana/grafana_home_dashboard.json"
+-    mode: "0660"
+-  when: grafana_custom_dashboard_file.stat.exists
++  with_items: "{{ dict( check_extra_conf_grafana.files | map(attribute='path') | map('basename') | zip(check_extra_conf_grafana.files) ) | dict2items | map(attribute='value') }}"
+   notify:
+     - Restart grafana container
+ 
+@@ -97,10 +82,7 @@
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
+     - enable_prometheus | bool
+-  with_first_found:
+-    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/prometheus.yaml"
+-    - "{{ node_custom_config }}/grafana/prometheus.yaml"
+-    - "prometheus.yaml.j2"
++  with_first_found: "{{ grafana_prometheus_config_paths }}"
+   notify:
+     - Restart grafana container
+ 
+@@ -115,43 +97,62 @@
+   when:
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
+-  with_first_found:
+-    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/provisioning.yaml"
+-    - "{{ node_custom_config }}/grafana/provisioning.yaml"
+-    - "{{ role_path }}/templates/provisioning.yaml.j2"
++  with_first_found: "{{ grafana_provisioning_config_paths }}"
+   notify:
+     - Restart grafana container
+ 
+-- name: Check if the folder for custom grafana dashboards exists
+-  stat:
+-    path: "{{ node_custom_config }}/grafana/dashboards"
++- name: Find custom grafana dashboards
++  find:
++    paths: "{{ grafana_custom_dashboards_paths }}"
++    recurse: true
+   delegate_to: localhost
+-  register: grafana_custom_dashboards_folder
++  register: grafana_custom_dashboards
+   run_once: True
+ 
+-- name: Remove templated Grafana dashboards
++- name: Find templated grafana dashboards
+   become: true
+   vars:
+     service: "{{ grafana_services['grafana'] }}"
++  find:
++    path: "{{ node_config_directory }}/grafana/dashboards"
++    recurse: true
++    file_type: any
++  register: grafana_templated_dashboards
++  when:
++    - inventory_hostname in groups[service.group]
++    - service.enabled | bool
++
++- name: Prune templated Grafana dashboards
++  become: true
++  vars:
++    service: "{{ grafana_services['grafana'] }}"
++    dashboards_templated_path_regex: "^{{ node_config_directory | regex_escape }}/grafana/dashboards/(.*)$"
++    dashboards_config_paths_regex: "^({{ grafana_custom_dashboards_paths | map('regex_escape') | join('|') }})/(.*)$"
++    dashboards_templated_relative_path: "{{ grafana_templated_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_templated_path_regex, '\\1') }}"
++    dashboards_config_relative_path: "{{ grafana_custom_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_config_paths_regex, '\\2') | unique }}"
+   file:
+     state: absent
+-    path: "{{ node_config_directory }}/grafana/dashboards/"
++    path: "{{ node_config_directory }}/grafana/dashboards/{{ item }}"
+   when:
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
++  with_items: "{{ dashboards_templated_relative_path | reject('in', dashboards_config_relative_path) | reject('in', dashboards_config_relative_path | map('dirname')) }}"
++  notify:
++    - Restart grafana container
+ 
+ - name: Copying over custom dashboards
+   vars:
+     service: "{{ grafana_services['grafana'] }}"
++    dashboards_config_paths_regex: "^({{ grafana_custom_dashboards_paths | map('regex_escape') | join('|') }})/(.*)$"
++    dashboards_config_relative_path: "{{ grafana_custom_dashboards.files | map(attribute='path') | map('regex_replace', dashboards_config_paths_regex,'\\2') }}"
+   copy:
+-    src: "{{ node_custom_config }}/grafana/dashboards"
+-    dest: "{{ node_config_directory }}/grafana/"
++    src: "{{ item.value.path }}"
++    dest: "{{ node_config_directory }}/grafana/dashboards/{{ item.key | dirname }}/"
+     mode: "0660"
+   become: true
+   when:
+-    - grafana_custom_dashboards_folder.stat.exists
+-    - grafana_custom_dashboards_folder.stat.isdir
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool
++  with_items: "{{ dict( dashboards_config_relative_path | zip(grafana_custom_dashboards.files) ) | dict2items }}"
+   notify:
+     - Restart grafana container
+diff --git a/ansible/roles/grafana/tasks/post_config.yml b/ansible/roles/grafana/tasks/post_config.yml
+index 82993cecf..97a9bc818 100644
+--- a/ansible/roles/grafana/tasks/post_config.yml
++++ b/ansible/roles/grafana/tasks/post_config.yml
+@@ -57,4 +57,4 @@
+   register: grafana_response
+   changed_when: grafana_response.status == 200
+   run_once: true
+-  when: grafana_custom_dashboard_file.stat.exists
++  when: "'grafana_home_dashboard.json' in check_extra_conf_grafana.files | map(attribute='path') | map('basename')"
+diff --git a/ansible/roles/grafana/templates/grafana.json.j2 b/ansible/roles/grafana/templates/grafana.json.j2
+index fcc3cc34b..fd113812a 100644
+--- a/ansible/roles/grafana/templates/grafana.json.j2
++++ b/ansible/roles/grafana/templates/grafana.json.j2
+@@ -7,21 +7,20 @@
+             "owner": "grafana",
+             "perm": "0600"
+         },
+-{% if check_extra_conf_grafana is defined %}{% if check_extra_conf_grafana.matched > 0 %}{% for plugin in check_extra_conf_grafana.files %}
++{% for extra_conf in check_extra_conf_grafana.files | map(attribute='path') | map('basename') | unique %}
+         {
+-            "source": "{{ container_config_directory }}/{{ plugin.path | basename }}",
+-            "dest": "/etc/grafana/{{ plugin.path | basename }}",
+-            "owner": "grafana",
+-            "perm": "0600"
+-        },
+-{% endfor %}{% endif %}{% endif %}
+-        {
+-            "source": "{{ container_config_directory }}/grafana_home_dashboard.json",
++            "source": "{{ container_config_directory }}/{{ extra_conf }}",
++{%   if extra_conf  == 'grafana_home_dashboard.json' %}
+             "dest": "/usr/share/grafana/public/dashboards/home.json",
+             "owner": "root",
+-            "perm": "0644",
+-            "optional": true
++            "perm": "0644"
++{%   else %}
++            "dest": "/etc/grafana/{{ extra_conf }}",
++            "owner": "grafana",
++            "perm": "0600"
++{%   endif %}
+         },
++{% endfor %}
+         {
+             "source": "{{ container_config_directory }}/prometheus.yaml",
+             "dest": "/etc/grafana/provisioning/datasources/prometheus.yaml",
+diff --git a/ansible/roles/prometheus/defaults/main.yml b/ansible/roles/prometheus/defaults/main.yml
+index cdd3cf485..b5e03ff9b 100644
+--- a/ansible/roles/prometheus/defaults/main.yml
++++ b/ansible/roles/prometheus/defaults/main.yml
+@@ -134,6 +134,12 @@ prometheus_services:
+ ####################
+ # Prometheus Server
+ ####################
++prometheus_custom_alert_paths:
++  - "{{ node_custom_config }}/prometheus/"
++
++prometheus_common_config_overrides_paths:
++  - "{{ node_custom_config }}/prometheus/prometheus.yml.d"
++
+ prometheus_external_labels:
+ #  <labelname>: <labelvalue>
+ 
+diff --git a/ansible/roles/prometheus/tasks/config.yml b/ansible/roles/prometheus/tasks/config.yml
+index 9ad3fa911..fb12d57b7 100644
+--- a/ansible/roles/prometheus/tasks/config.yml
++++ b/ansible/roles/prometheus/tasks/config.yml
+@@ -31,7 +31,7 @@
+ 
+ - name: Find custom prometheus alert rules files
+   find:
+-    path: "{{ node_custom_config }}/prometheus/"
++    paths: "{{ prometheus_custom_alert_paths }}"
+     pattern: "*.rules"
+   run_once: True
+   delegate_to: localhost
+@@ -51,15 +51,14 @@
+     - inventory_hostname in groups[service.group]
+     - service.enabled | bool and enable_prometheus_alertmanager | bool
+     - prometheus_alert_rules is defined and prometheus_alert_rules.files | length > 0
+-  with_items: "{{ prometheus_alert_rules.files }}"
++  with_items: "{{ dict( prometheus_alert_rules.files | map(attribute='path') | map('basename') | zip(prometheus_alert_rules.files) ) | dict2items | map(attribute='value') }}"
+   notify:
+     - Restart prometheus-server container
+ 
+ - name: Find prometheus common config overrides
+   find:
+     # NOTE(wszumski): Non-existent paths don't produce a failure
+-    paths:
+-      - "{{ node_custom_config }}/prometheus/prometheus.yml.d"
++    paths: "{{ prometheus_common_config_overrides_paths }}"
+     patterns: "*.yml"
+   delegate_to: localhost
+   register: prometheus_common_config_overrides_result
+@@ -80,8 +79,9 @@
+   become: true
+   vars:
+     service: "{{ prometheus_services['prometheus-server'] }}"
+-    common_overrides: "{{ prometheus_common_config_overrides_result.files | map(attribute='path') | list }}"
++    _common_overrides: "{{ prometheus_common_config_overrides_result.files | map(attribute='path') | list }}"
+     host_overrides: "{{ prometheus_host_config_overrides_result.files | map(attribute='path') | list }}"
++    common_overrides: "{{ dict( _common_overrides | map('basename') | zip(_common_overrides) ) | dict2items | sort(attribute='key') | map(attribute='value') | list }}"
+   merge_yaml:
+     sources: "{{ [item] + common_overrides + host_overrides }}"
+     dest: "{{ node_config_directory }}/prometheus-server/prometheus.yml"
+diff --git a/ansible/roles/prometheus/templates/prometheus.yml.j2 b/ansible/roles/prometheus/templates/prometheus.yml.j2
+index 6b3f08c31..2d8c702eb 100644
+--- a/ansible/roles/prometheus/templates/prometheus.yml.j2
++++ b/ansible/roles/prometheus/templates/prometheus.yml.j2
+@@ -11,8 +11,8 @@ global:
+ 
+ {% if prometheus_alert_rules.files is defined and prometheus_alert_rules.files | length  > 0 %}
+ rule_files:
+-{% for rule in prometheus_alert_rules.files %}
+-  - "/etc/prometheus/{{ rule.path | basename }}"
++{% for rule in prometheus_alert_rules.files | map(attribute='path') | map('basename') | unique %}
++  - "/etc/prometheus/{{ rule }}"
+ {% endfor %}
+ {% endif %}
+ 


### PR DESCRIPTION
Add patches to support deployment of kolla-operations resources from the kolla-ansible container.

Subject: [PATCH 1/4] Fix redundant extra config files in grafana role

Task `Check if extra configuration file exists` picks up all files in `{{ node_custom_config }}/grafana` including those that get handled specially later on.
While `prometheus.yml` and `provisioning.yml` are best excluded from extra config , because their treatment requires more than just copying, `grafana_home_dashboard.json` may simply be treated as extra config, which saves the execution of two additional tasks..

Subject: [PATCH 2/4] Improve grafana dashboard deployment

Unitl now grafana dashboards were always removed and redeployed leading to a restart of the grafana services on every deployment. The task is changed to find all individual dashboards that are going to be deployed and all which are currently deployed. Dashboards only appearing in the latter group wil be removed, while dashboards in the former group will be deployed individually, leaving it to ansible to figure which changes need to be made.
This way only removal or changes to dashboards will lead to a restart of grafana containers.

Subject: [PATCH 3/4] Allow extension of grafana override paths

Subject: [PATCH 4/4] Allow extension of prometheus override paths

Part of https://github.com/osism/issues/issues/1012