### PR TITLE
Add hosts-kolla-loadbalancer parameter

### DIFF
--- a/patches/2023.2/hosts-kolla-loadbalancer.patch
+++ b/patches/2023.2/hosts-kolla-loadbalancer.patch
@@ -1,0 +1,540 @@
+--- a/ansible/roles/loadbalancer/tasks/main.yml
++++ b/ansible/roles/loadbalancer/tasks/main.yml
+@@ -1,3 +1,3 @@
+ ---
+ - include_tasks: "{{ kolla_action }}.yml"
+-  when: inventory_hostname in groups['loadbalancer']
++  when: inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+--- a/ansible/roles/loadbalancer/tasks/precheck.yml
++++ b/ansible/roles/loadbalancer/tasks/precheck.yml
+@@ -23,7 +23,7 @@
+   check_mode: false
+   when:
+     - enable_keepalived | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+ 
+ - name: Group hosts by whether they are running HAProxy
+   group_by:
+@@ -32,7 +32,7 @@
+   check_mode: false
+   when:
+     - enable_haproxy | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+ 
+ - name: Group hosts by whether they are running ProxySQL
+   group_by:
+@@ -41,14 +41,14 @@
+   check_mode: false
+   when:
+     - enable_proxysql | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+ 
+ - name: Set facts about whether we can run HAProxy and keepalived VIP prechecks
+   vars:
+     # NOTE(mgoddard): We can only reliably run this precheck if all hosts in
+     # the haproxy group are included in the batch. This may not be the case if
+     # using --limit or --serial.
+-    all_hosts_in_batch: "{{ groups['loadbalancer'] | difference(ansible_play_batch) | list | length == 0 }}"
++    all_hosts_in_batch: "{{ groups[hosts_kolla_loadbalancer|default('loadbalancer')] | difference(ansible_play_batch) | list | length == 0 }}"
+   set_fact:
+     keepalived_vip_prechecks: "{{ all_hosts_in_batch and groups['keepalived_running_True'] is not defined }}"
+     haproxy_vip_prechecks: "{{ all_hosts_in_batch and groups['haproxy_running_True'] is not defined }}"
+@@ -137,7 +137,7 @@
+   when:
+     - enable_haproxy | bool
+     - container_facts['haproxy'] is not defined
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+ 
+ - name: Checking free port for HAProxy monitor (api interface)
+   wait_for:
+@@ -149,7 +149,7 @@
+   when:
+     - enable_haproxy | bool
+     - container_facts['haproxy'] is not defined
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+ 
+ - name: Checking free port for HAProxy monitor (vip interface)
+   wait_for:
+@@ -161,7 +161,7 @@
+   when:
+     - enable_haproxy | bool
+     - haproxy_vip_prechecks
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - api_interface_address != kolla_internal_vip_address
+ 
+ - name: Checking free port for ProxySQL admin (api interface)
+@@ -174,7 +174,7 @@
+   when:
+     - enable_proxysql | bool
+     - container_facts['proxysql'] is not defined
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+ 
+ - name: Checking free port for ProxySQL admin (vip interface)
+   wait_for:
+@@ -186,7 +186,7 @@
+   when:
+     - enable_proxysql | bool
+     - proxysql_vip_prechecks
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - api_interface_address != kolla_internal_vip_address
+ 
+ # FIXME(yoctozepto): this req seems arbitrary, they need not be, just routable is fine
+@@ -203,7 +203,7 @@
+     - enable_haproxy | bool
+     - enable_keepalived | bool
+     - container_facts['keepalived'] is not defined
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+ 
+ - name: Getting haproxy stat
+   become: true
+@@ -226,7 +226,7 @@
+     state: stopped
+   when:
+     - enable_aodh | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('aodh_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -239,7 +239,7 @@
+     state: stopped
+   when:
+     - enable_barbican | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('barbican_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -252,7 +252,7 @@
+     state: stopped
+   when:
+     - enable_blazar | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('blazar_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -266,7 +266,7 @@
+   when:
+     - enable_ceph_rgw | bool
+     - enable_ceph_rgw_loadbalancer | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('radosgw') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -279,7 +279,7 @@
+     state: stopped
+   when:
+     - enable_cinder | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('cinder_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -292,7 +292,7 @@
+     state: stopped
+   when:
+     - enable_cloudkitty | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('cloudkitty_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -305,7 +305,7 @@
+     state: stopped
+   when:
+     - enable_cyborg | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('cyborg_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -318,7 +318,7 @@
+     state: stopped
+   when:
+     - enable_designate | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('designate_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -331,7 +331,7 @@
+     state: stopped
+   when:
+     - enable_glance | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('glance_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -344,7 +344,7 @@
+     state: stopped
+   when:
+     - enable_gnocchi | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('gnocchi_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -358,7 +358,7 @@
+   when:
+     - enable_freezer | bool
+     - haproxy_stat.find('freezer_api') == -1
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_vip_prechecks
+ 
+ - name: Checking free port for Grafana server HAProxy
+@@ -370,7 +370,7 @@
+     state: stopped
+   when:
+     - enable_grafana | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('grafana_server') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -383,7 +383,7 @@
+     state: stopped
+   when:
+     - enable_heat | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('heat_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -396,7 +396,7 @@
+     state: stopped
+   when:
+     - enable_heat | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('heat_api_cfn') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -409,7 +409,7 @@
+     state: stopped
+   when:
+     - enable_horizon | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('horizon') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -422,7 +422,7 @@
+     state: stopped
+   when:
+     - enable_ironic | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('ironic_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -435,7 +435,7 @@
+     state: stopped
+   when:
+     - enable_ironic | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('ironic_inspector') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -448,7 +448,7 @@
+     state: stopped
+   when:
+     - enable_keystone | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('keystone_internal') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -462,7 +462,7 @@
+   when:
+     - haproxy_enable_external_vip | bool
+     - enable_keystone | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('keystone_external') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -475,7 +475,7 @@
+     state: stopped
+   when:
+     - enable_magnum | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('magnum_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -488,7 +488,7 @@
+     state: stopped
+   when:
+     - enable_manila | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('manila_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -501,7 +501,7 @@
+     state: stopped
+   when:
+     - enable_mariadb | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('mariadb') == -1
+     - haproxy_vip_prechecks or proxysql_vip_prechecks
+ 
+@@ -514,7 +514,7 @@
+     state: stopped
+   when:
+     - enable_masakari | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('masakari_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -527,7 +527,7 @@
+     state: stopped
+   when:
+     - enable_mistral | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('mistral_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -540,7 +540,7 @@
+     state: stopped
+   when:
+     - enable_murano | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('murano_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -553,7 +553,7 @@
+     state: stopped
+   when:
+     - enable_neutron | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('neutron_server') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -566,7 +566,7 @@
+     state: stopped
+   when:
+     - enable_nova | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('nova_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -579,7 +579,7 @@
+     state: stopped
+   when:
+     - enable_nova | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('nova_metadata') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -593,7 +593,7 @@
+   when:
+     - enable_nova | bool
+     - nova_console == 'novnc'
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('nova_novncproxy') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -608,7 +608,7 @@
+     - enable_nova | bool
+     - haproxy_stat.find('nova_serialconsole_proxy') == -1
+     - enable_nova_serialconsole_proxy | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_vip_prechecks
+ 
+ - name: Checking free port for Nova Spice HTML5 HAProxy
+@@ -621,7 +621,7 @@
+   when:
+     - enable_nova | bool
+     - nova_console == 'spice'
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('nova_spicehtml5proxy') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -634,7 +634,7 @@
+     state: stopped
+   when:
+     - enable_nova | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('placement_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -647,7 +647,7 @@
+     state: stopped
+   when:
+     - enable_octavia | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('octavia_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -660,7 +660,7 @@
+     state: stopped
+   when:
+     - enable_opensearch | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('opensearch') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -673,7 +673,7 @@
+     state: stopped
+   when:
+     - enable_opensearch_dashboards | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('opensearch_dashboards') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -686,7 +686,7 @@
+     state: stopped
+   when:
+     - enable_rabbitmq | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('rabbitmq_management') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -698,7 +698,7 @@
+     state: stopped
+   when:
+     - enable_outward_rabbitmq | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('outward_rabbitmq_management') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -711,7 +711,7 @@
+     state: stopped
+   when:
+     - enable_sahara | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('sahara_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -724,7 +724,7 @@
+     state: stopped
+   when:
+     - enable_senlin | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('senlin_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -737,7 +737,7 @@
+     state: stopped
+   when:
+     - enable_solum | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('solum_application_deployment') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -750,7 +750,7 @@
+     state: stopped
+   when:
+     - enable_solum | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('solum_image_builder') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -763,7 +763,7 @@
+     state: stopped
+   when:
+     - enable_swift | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('swift_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -776,7 +776,7 @@
+     state: stopped
+   when:
+     - enable_tacker | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('tacker_server') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -789,7 +789,7 @@
+     state: stopped
+   when:
+     - enable_trove | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('trove_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -802,7 +802,7 @@
+     state: stopped
+   when:
+     - enable_watcher | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('watcher_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -815,7 +815,7 @@
+     state: stopped
+   when:
+     - enable_zun | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('zun_api') == -1
+     - haproxy_vip_prechecks
+ 
+@@ -827,7 +827,7 @@
+     state: stopped
+   when:
+     - enable_vitrage | bool
+-    - inventory_hostname in groups['loadbalancer']
++    - inventory_hostname in groups[hosts_kolla_loadbalancer|default('loadbalancer')]
+     - haproxy_stat.find('vitrage_api') == -1
+     - haproxy_vip_prechecks
+ 
+--- a/ansible/roles/loadbalancer/templates/keepalived/keepalived.conf.j2
++++ b/ansible/roles/loadbalancer/templates/keepalived/keepalived.conf.j2
+@@ -12,13 +12,13 @@ vrrp_instance kolla_internal_vip_{{ keepalived_virtual_router_id }} {
+     nopreempt
+     interface {{ api_interface }}
+     virtual_router_id {{ keepalived_virtual_router_id }}
+-    priority {{ groups['loadbalancer'].index(inventory_hostname) + 1 }}
++    priority {{ groups[hosts_kolla_loadbalancer|default('loadbalancer')].index(inventory_hostname) + 1 }}
+     advert_int 1
+ {% if keepalived_traffic_mode == 'unicast' %}
+     unicast_src_ip {{ api_interface_address }}
+-{% if groups['loadbalancer'] | length > 1 %}
++{% if groups[hosts_kolla_loadbalancer|default('loadbalancer')] | length > 1 %}
+     unicast_peer {
+-{% for host in groups['loadbalancer'] %}
++{% for host in groups[hosts_kolla_loadbalancer|default('loadbalancer')] %}
+ {% set ip_addr = 'api' | kolla_address(host) %}
+ {% if ip_addr != api_interface_address %}
+         {{ ip_addr }}


### PR DESCRIPTION
This patch adds the hosts-kolla-loadbalancer parameter to the loadbalancer role. With this parameter it's possible to change the inventory group that should be used to identify loadbalancer nodes. This is required to be able to deploy multiple independent loadbalancer services by using the sub environments.