### PR TITLE
2023.1/2023.2: add backport-921071.patch

### DIFF
--- a/patches/2023.1/backport-921071.patch
+++ b/patches/2023.1/backport-921071.patch
@@ -1,0 +1,33 @@
+From 5a13877ae5ccceab92476579529d75035fd35697 Mon Sep 17 00:00:00 2001
+From: Christian Berendt <berendt@osism.tech>
+Date: Mon, 03 Jun 2024 21:53:06 +0200
+Subject: [PATCH] loadbalancer: fail on failed "Wait for backup * to start" handlers
+
+If a faulty HAProxy/ProxySQL configuration is applied and the backup
+HAProxy/ProxySQL containers have not been successfully restarted, a
+hard stop must be performed so that the master HAProxy/ProxySQL
+container with the faulty configuration is not also stopped and restarted.
+
+Change-Id: I82b2003e90993df5227c58b5511adcc391742bda
+---
+
+diff --git a/ansible/roles/loadbalancer/handlers/main.yml b/ansible/roles/loadbalancer/handlers/main.yml
+index a94a740..1e94835 100644
+--- a/ansible/roles/loadbalancer/handlers/main.yml
++++ b/ansible/roles/loadbalancer/handlers/main.yml
+@@ -122,6 +122,7 @@
+   wait_for:
+     host: "{{ api_interface_address }}"
+     port: "{{ haproxy_monitor_port }}"
++  any_errors_fatal: true
+ 
+ - name: Start backup proxysql container
+   vars:
+@@ -156,6 +157,7 @@
+   wait_for:
+     host: "{{ api_interface_address }}"
+     port: "{{ proxysql_admin_port }}"
++  any_errors_fatal: true
+ 
+ - name: Start backup keepalived container
+   vars:

--- a/patches/2023.2/backport-921071.patch
+++ b/patches/2023.2/backport-921071.patch
@@ -1,0 +1,33 @@
+From 5a13877ae5ccceab92476579529d75035fd35697 Mon Sep 17 00:00:00 2001
+From: Christian Berendt <berendt@osism.tech>
+Date: Mon, 03 Jun 2024 21:53:06 +0200
+Subject: [PATCH] loadbalancer: fail on failed "Wait for backup * to start" handlers
+
+If a faulty HAProxy/ProxySQL configuration is applied and the backup
+HAProxy/ProxySQL containers have not been successfully restarted, a
+hard stop must be performed so that the master HAProxy/ProxySQL
+container with the faulty configuration is not also stopped and restarted.
+
+Change-Id: I82b2003e90993df5227c58b5511adcc391742bda
+---
+
+diff --git a/ansible/roles/loadbalancer/handlers/main.yml b/ansible/roles/loadbalancer/handlers/main.yml
+index a94a740..1e94835 100644
+--- a/ansible/roles/loadbalancer/handlers/main.yml
++++ b/ansible/roles/loadbalancer/handlers/main.yml
+@@ -122,6 +122,7 @@
+   wait_for:
+     host: "{{ api_interface_address }}"
+     port: "{{ haproxy_monitor_port }}"
++  any_errors_fatal: true
+ 
+ - name: Start backup proxysql container
+   vars:
+@@ -156,6 +157,7 @@
+   wait_for:
+     host: "{{ api_interface_address }}"
+     port: "{{ proxysql_admin_port }}"
++  any_errors_fatal: true
+ 
+ - name: Start backup keepalived container
+   vars:


### PR DESCRIPTION
loadbalancer: fail on failed "Wait for backup * to start" handlers

If a faulty HAProxy/ProxySQL configuration is applied and the backup HAProxy/ProxySQL containers have not been successfully restarted, a hard stop must be performed so that the master HAProxy/ProxySQL container with the faulty configuration is not also stopped and restarted.

Closes osism/issues#483