### PR TITLE
Add barbican_cs_auth_keys.patch

### DIFF
--- a/patches/2023.1/barbican_cs_auth_keys.patch
+++ b/patches/2023.1/barbican_cs_auth_keys.patch
@@ -1,0 +1,29 @@
+--- a/ansible/roles/barbican/defaults/main.yml
++++ b/ansible/roles/barbican/defaults/main.yml
+@@ -4,6 +4,8 @@ barbican_services:
+     container_name: barbican_api
+     group: barbican-api
+     enabled: true
++    environment:
++      CS_AUTH_KEYS: "{{ barbican_cs_auth_keys | default('') }}"
+     image: "{{ barbican_api_image_full }}"
+     volumes: "{{ barbican_api_default_volumes + barbican_api_extra_volumes }}"
+     dimensions: "{{ barbican_api_dimensions }}"
+@@ -28,6 +30,8 @@ barbican_services:
+     container_name: barbican_keystone_listener
+     group: barbican-keystone-listener
+     enabled: true
++    environment:
++      CS_AUTH_KEYS: "{{ barbican_cs_auth_keys | default('') }}"
+     image: "{{ barbican_keystone_listener_image_full }}"
+     volumes: "{{ barbican_keystone_listener_default_volumes + barbican_keystone_listener_extra_volumes }}"
+     dimensions: "{{ barbican_keystone_listener_dimensions }}"
+@@ -36,6 +40,8 @@ barbican_services:
+     container_name: barbican_worker
+     group: barbican-worker
+     enabled: true
++    environment:
++      CS_AUTH_KEYS: "{{ barbican_cs_auth_keys | default('') }}"
+     image: "{{ barbican_worker_image_full }}"
+     volumes: "{{ barbican_worker_default_volumes + barbican_worker_extra_volumes }}"
+     dimensions: "{{ barbican_worker_dimensions }}"

--- a/patches/2023.2/barbican_cs_auth_keys.patch
+++ b/patches/2023.2/barbican_cs_auth_keys.patch
@@ -1,0 +1,29 @@
+--- a/ansible/roles/barbican/defaults/main.yml
++++ b/ansible/roles/barbican/defaults/main.yml
+@@ -4,6 +4,8 @@ barbican_services:
+     container_name: barbican_api
+     group: barbican-api
+     enabled: true
++    environment:
++      CS_AUTH_KEYS: "{{ barbican_cs_auth_keys | default('') }}"
+     image: "{{ barbican_api_image_full }}"
+     volumes: "{{ barbican_api_default_volumes + barbican_api_extra_volumes }}"
+     dimensions: "{{ barbican_api_dimensions }}"
+@@ -28,6 +30,8 @@ barbican_services:
+     container_name: barbican_keystone_listener
+     group: barbican-keystone-listener
+     enabled: true
++    environment:
++      CS_AUTH_KEYS: "{{ barbican_cs_auth_keys | default('') }}"
+     image: "{{ barbican_keystone_listener_image_full }}"
+     volumes: "{{ barbican_keystone_listener_default_volumes + barbican_keystone_listener_extra_volumes }}"
+     dimensions: "{{ barbican_keystone_listener_dimensions }}"
+@@ -36,6 +40,8 @@ barbican_services:
+     container_name: barbican_worker
+     group: barbican-worker
+     enabled: true
++    environment:
++      CS_AUTH_KEYS: "{{ barbican_cs_auth_keys | default('') }}"
+     image: "{{ barbican_worker_image_full }}"
+     volumes: "{{ barbican_worker_default_volumes + barbican_worker_extra_volumes }}"
+     dimensions: "{{ barbican_worker_dimensions }}"


### PR DESCRIPTION
This allows to set the CS_AUTH_KEYS environment variable in all barbican services. Required by the Utimaco HSM.