### PR TITLE
Ignore all Python UserWarnings

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -230,6 +230,8 @@ FROM python:${PYTHON_VERSION}-slim-bookworm
 
 COPY --link --from=builder / /
 
+ENV PYTHONWARNINGS="ignore::UserWarning"
+
 VOLUME ["/ansible/cache", "/ansible/logs", "/ansible/secrets", "/share", "/interface"]
 USER dragon
 WORKDIR /ansible


### PR DESCRIPTION
It looks like this is the only way to get rid of the CryptographyDeprecationWarning warnings.