### PR TITLE
Fix barbican_cs_auth_keys.patch patch (pt. 2)

### DIFF
--- a/patches/2023.1/barbican_cs_auth_keys.patch
+++ b/patches/2023.1/barbican_cs_auth_keys.patch
@@ -27,6 +27,31 @@
      image: "{{ barbican_worker_image_full }}"
      volumes: "{{ barbican_worker_default_volumes + barbican_worker_extra_volumes }}"
      dimensions: "{{ barbican_worker_dimensions }}"
+--- a/ansible/roles/barbican/handlers/main.yml
++++ b/ansible/roles/barbican/handlers/main.yml
+@@ -12,6 +12,7 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
+ 
+@@ -28,6 +29,7 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
+ 
+@@ -44,5 +46,6 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
 --- a/ansible/roles/barbican/tasks/check-containers.yml
 +++ b/ansible/roles/barbican/tasks/check-containers.yml
 @@ -9,6 +9,7 @@

--- a/patches/2023.2/barbican_cs_auth_keys.patch
+++ b/patches/2023.2/barbican_cs_auth_keys.patch
@@ -27,6 +27,31 @@
      image: "{{ barbican_worker_image_full }}"
      volumes: "{{ barbican_worker_default_volumes + barbican_worker_extra_volumes }}"
      dimensions: "{{ barbican_worker_dimensions }}"
+--- a/ansible/roles/barbican/handlers/main.yml
++++ b/ansible/roles/barbican/handlers/main.yml
+@@ -12,6 +12,7 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
+ 
+@@ -28,6 +29,7 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
+ 
+@@ -44,5 +46,6 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
 --- a/ansible/roles/barbican/tasks/check-containers.yml
 +++ b/ansible/roles/barbican/tasks/check-containers.yml
 @@ -9,6 +9,7 @@

--- a/patches/2024.1/barbican_cs_auth_keys.patch
+++ b/patches/2024.1/barbican_cs_auth_keys.patch
@@ -27,6 +27,31 @@
      image: "{{ barbican_worker_image_full }}"
      volumes: "{{ barbican_worker_default_volumes + barbican_worker_extra_volumes }}"
      dimensions: "{{ barbican_worker_dimensions }}"
+--- a/ansible/roles/barbican/handlers/main.yml
++++ b/ansible/roles/barbican/handlers/main.yml
+@@ -12,6 +12,7 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
+ 
+@@ -28,6 +29,7 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
+ 
+@@ -44,5 +46,6 @@
+     volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
++    environment: "{{ service.environment | default(omit) }}"
+   when:
+     - kolla_action != "config"
 --- a/ansible/roles/barbican/tasks/check-containers.yml
 +++ b/ansible/roles/barbican/tasks/check-containers.yml
 @@ -9,6 +9,7 @@


### PR DESCRIPTION
The environment parameter has also to be added to all service handlers.

Related to osism/issues#1099