### PR TITLE
make default group configurable and set it to generic

### DIFF
--- a/files/playbooks/2023.1/kolla-common.yml
+++ b/files/playbooks/2023.1/kolla-common.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role common
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   serial: '{{ serial | default("0") }}'
   roles:
     - {role: common, tags: common}

--- a/files/playbooks/2023.2/kolla-common.yml
+++ b/files/playbooks/2023.2/kolla-common.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role common
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   serial: '{{ serial | default("0") }}'
   roles:
     - {role: common, tags: common}

--- a/files/playbooks/2024.1/kolla-common.yml
+++ b/files/playbooks/2024.1/kolla-common.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role common
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   serial: '{{ serial | default("0") }}'
   roles:
     - {role: common, tags: common}

--- a/files/playbooks/kolla-facts.yml
+++ b/files/playbooks/kolla-facts.yml
@@ -1,6 +1,6 @@
 ---
 - name: Gather facts for all hosts
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Gather facts for all hosts
@@ -9,7 +9,7 @@
         gather_subset: "{{ osism_setup_gather_subset | default('') }}"
 
 - name: Gather facts for all hosts (if using --limit)
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Gather facts for all hosts (if using --limit)

--- a/files/playbooks/kolla-loadbalancer-aodh.yml
+++ b/files/playbooks/kolla-loadbalancer-aodh.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-barbican.yml
+++ b/files/playbooks/kolla-loadbalancer-barbican.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-blazar.yml
+++ b/files/playbooks/kolla-loadbalancer-blazar.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-ceph-rgw.yml
+++ b/files/playbooks/kolla-loadbalancer-ceph-rgw.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-cinder.yml
+++ b/files/playbooks/kolla-loadbalancer-cinder.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-cloudkitty.yml
+++ b/files/playbooks/kolla-loadbalancer-cloudkitty.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-designate.yml
+++ b/files/playbooks/kolla-loadbalancer-designate.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-glance.yml
+++ b/files/playbooks/kolla-loadbalancer-glance.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-gnocchi.yml
+++ b/files/playbooks/kolla-loadbalancer-gnocchi.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-grafana.yml
+++ b/files/playbooks/kolla-loadbalancer-grafana.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-heat.yml
+++ b/files/playbooks/kolla-loadbalancer-heat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-horizon.yml
+++ b/files/playbooks/kolla-loadbalancer-horizon.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-ironic.yml
+++ b/files/playbooks/kolla-loadbalancer-ironic.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-keystone.yml
+++ b/files/playbooks/kolla-loadbalancer-keystone.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-magnum.yml
+++ b/files/playbooks/kolla-loadbalancer-magnum.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-manila.yml
+++ b/files/playbooks/kolla-loadbalancer-manila.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-mariadb.yml
+++ b/files/playbooks/kolla-loadbalancer-mariadb.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-masakari.yml
+++ b/files/playbooks/kolla-loadbalancer-masakari.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-memcached.yml
+++ b/files/playbooks/kolla-loadbalancer-memcached.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-mistral.yml
+++ b/files/playbooks/kolla-loadbalancer-mistral.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-monasca.yml
+++ b/files/playbooks/kolla-loadbalancer-monasca.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-neutron.yml
+++ b/files/playbooks/kolla-loadbalancer-neutron.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-ng.yml
+++ b/files/playbooks/kolla-loadbalancer-ng.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-nova.yml
+++ b/files/playbooks/kolla-loadbalancer-nova.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-octavia.yml
+++ b/files/playbooks/kolla-loadbalancer-octavia.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-opensearch.yml
+++ b/files/playbooks/kolla-loadbalancer-opensearch.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-placement.yml
+++ b/files/playbooks/kolla-loadbalancer-placement.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-prometheus.yml
+++ b/files/playbooks/kolla-loadbalancer-prometheus.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-rabbitmq.yml
+++ b/files/playbooks/kolla-loadbalancer-rabbitmq.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-senlin.yml
+++ b/files/playbooks/kolla-loadbalancer-senlin.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-skyline.yml
+++ b/files/playbooks/kolla-loadbalancer-skyline.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-swift.yml
+++ b/files/playbooks/kolla-loadbalancer-swift.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-trove.yml
+++ b/files/playbooks/kolla-loadbalancer-trove.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-watcher.yml
+++ b/files/playbooks/kolla-loadbalancer-watcher.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-loadbalancer-zun.yml
+++ b/files/playbooks/kolla-loadbalancer-zun.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on Kolla action

--- a/files/playbooks/kolla-purge.yml
+++ b/files/playbooks/kolla-purge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Confirm whether user really meant to purge the kolla environment
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
 
   vars_prompt:
     - name: ireallymeanit
@@ -25,7 +25,7 @@
         - ireallymeanit != 'yes' or ireallyreallymeanit != 'ireallyreallymeanit'
 
 - name: Purge kolla environment
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
 
   vars:
     destroy_include_images: false

--- a/files/playbooks/kolla-testbed-identity.yml
+++ b/files/playbooks/kolla-testbed-identity.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on OpenStack release
@@ -91,7 +91,7 @@
 
 - name: Apply common role
   gather_facts: false
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   serial: '{{ kolla_serial | default("0") }}'
   roles:
     - role: common

--- a/files/playbooks/kolla-testbed.yml
+++ b/files/playbooks/kolla-testbed.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   gather_facts: false
   tasks:
     - name: Group hosts based on OpenStack release
@@ -91,7 +91,7 @@
 
 - name: Apply common role
   gather_facts: false
-  hosts: all
+  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
   serial: '{{ kolla_serial | default("0") }}'
   roles:
     - role: common

--- a/patches/2023.1/nova-playbook-group-hosts-based-on-configuration.patch
+++ b/patches/2023.1/nova-playbook-group-hosts-based-on-configuration.patch
@@ -3,7 +3,7 @@
 @@ -1,4 +1,21 @@
  ---
 +- name: Group hosts based on configuration
-+  hosts: all
++  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
 +  gather_facts: false
 +  tasks:
 +    - name: Group hosts based on OpenStack release

--- a/patches/2023.2/nova-playbook-group-hosts-based-on-configuration.patch
+++ b/patches/2023.2/nova-playbook-group-hosts-based-on-configuration.patch
@@ -3,7 +3,7 @@
 @@ -1,4 +1,21 @@
  ---
 +- name: Group hosts based on configuration
-+  hosts: all
++  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
 +  gather_facts: false
 +  tasks:
 +    - name: Group hosts based on OpenStack release

--- a/patches/2024.1/nova-playbook-group-hosts-based-on-configuration.patch
+++ b/patches/2024.1/nova-playbook-group-hosts-based-on-configuration.patch
@@ -3,7 +3,7 @@
 @@ -1,4 +1,21 @@
  ---
 +- name: Group hosts based on configuration
-+  hosts: all
++  hosts: "{{ hosts_kolla_default_group|default('generic') }}"
 +  gather_facts: false
 +  tasks:
 +    - name: Group hosts based on OpenStack release

--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -1,7 +1,6 @@
 ---
 - name: Build kolla-ansible image
   hosts: all
-
   vars:
     python_venv_dir: /tmp/venv
 


### PR DESCRIPTION
Since we want to configure the basic configuration of the switches automatically via Ansible 
(the things that don't make sense via the Sonic Management Framework), I have also added them in 
[dedicated groups](https://github.com/SovereignCloudStack/hardware-landscape/blob/main/inventory/10-custom) in our inventory.

In doing so, I noticed the following:
As soon as these are defined in any group, they become part of the “all” group and
Kolla Ansible tries to configure the switches like Openstack systems with `osism apply common`.

This makes little sense for switches, and it is possible that it could have unwanted effects
on systems other than Kolla Ansible (Ceph, Managers, Monitoring).

It seems that the plays in [container-image-kolla-ansible](https://github.com/osism/container-image-kolla-ansible/) are [wired to “all”](see https://github.com/search?q=repo%3Aosism%2Fcontainer-image-kolla-ansible%20%22hosts%3A%20all%22&type=code).

I have now automated the process in changing this:
```
cd container-image-kolla-ansible
git grep -P “hosts: all”|cut -d “:” -f1 |sort -u|xargs sed -i “~s,hosts: all,hosts: {{ hosts_default_group|default(‘generic’) }},”
```

Does that make sense, or have I overlooked something?
Would it perhaps make sense to define a `hosts_kolla_group` (with default "generic" ) instead of `hosts_default_group`?