### PR TITLE
Pin MarkupSafe

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==6.0.2
 pottery==3.0.0
 requests==2.32.3
 yq==3.4.3
+MarkupSafe<3.0.0  # https://github.com/osism/issues/issues/1161 


### PR DESCRIPTION
MarkupSafe version `3.0.0` introduces an error during rednering of loadbalancer service templates (e.g. [1])
Temporarily fixed by pining 'MarkupSafe<3.0.0'.

Part of https://github.com/osism/issues/issues/1161

[1]
```
TASK [haproxy-config : Copying over barbican haproxy config] *****************************************************************
task path: /ansible/roles/haproxy-config/tasks/main.yml:2
[...]
SystemError: <built-in function _escape_inner> returned NULL without setting an exception
```