### PR TITLE
Revert "Pin MarkupSafe (#695)"

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -3,4 +3,3 @@ PyYAML==6.0.2
 pottery==3.0.0
 requests==2.32.3
 yq==3.4.3
-MarkupSafe<3.0.0  # https://github.com/osism/issues/issues/1161 


### PR DESCRIPTION
This reverts commit 9269e57d4529d12cbd9d4bc4f91d395bcd35d2d0.

The issue in MarkupSafe has been fixed with release 3.0.2 ([1])

Closes: https://github.com/osism/issues/issues/1161

[1]
https://github.com/pallets/markupsafe/releases/tag/3.0.2 https://github.com/pallets/markupsafe/issues/472