### PR TITLE
Remove openstacksdk from the requirements

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -23,4 +23,3 @@ paramiko==3.5.0
 PyMySQL==1.1.1
 requests==2.32.3
 ruamel.yaml==0.18.6
-openstacksdk==4.1.0


### PR DESCRIPTION
openstacksdk is already a requirement of python-osism. Remove it here to avoid version conflicts.