### PR TITLE
Retry IPA image downloads

### DIFF
--- a/files/playbooks/kolla-ironic-download-ipa-images.yml
+++ b/files/playbooks/kolla-ironic-download-ipa-images.yml
@@ -30,6 +30,10 @@
         mode: 0644
       when: enable_ironic_agent_download_images | bool
       environment: "{{ proxy_proxies | default({}) }}"
+      register: result
+      retries: 3
+      delay: 10
+      until: result is not failed
 
     - name: Download ironic-agent kernel
       ansible.builtin.get_url:
@@ -39,3 +43,7 @@
         mode: 0644
       when: enable_ironic_agent_download_images | bool
       environment: "{{ proxy_proxies | default({}) }}"
+      register: result
+      retries: 3
+      delay: 10
+      until: result is not failed


### PR DESCRIPTION
Sometimes the HTTP server does not respond as desired. Then try it several times.