### PR TITLE
Use github.com instead of opendev.org for the moment

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -132,8 +132,8 @@ ansible-galaxy collection install -v -f -r /ansible/galaxy/requirements.yml -p /
 ln -s /usr/share/ansible/collections /ansible/collections
 
 # prepare project repository
-if [ "$OPENSTACK_VERSION" = "master" ]; then git clone https://opendev.org/openstack/kolla-ansible /repository; fi
-if [ "$OPENSTACK_VERSION" != "master" ]; then git clone -b stable/$OPENSTACK_VERSION https://opendev.org/openstack/kolla-ansible /repository; fi
+if [ "$OPENSTACK_VERSION" = "master" ]; then git clone https://github.com/openstack/kolla-ansible /repository; fi
+if [ "$OPENSTACK_VERSION" != "master" ]; then git clone -b stable/$OPENSTACK_VERSION https://github.com/openstack/kolla-ansible /repository; fi
 
 # apply patches
 for patchfile in $(find /patches/$OPENSTACK_VERSION -name "*.patch"); do

--- a/files/scripts/change.sh
+++ b/files/scripts/change.sh
@@ -14,7 +14,7 @@ if [[ "$1" == "kolla-ansible" ]]; then
     rm -rf /ansible/roles/*
     rm -rf /repository
 
-    git clone https://opendev.org/openstack/kolla-ansible /repository
+    git clone https://github.com/openstack/kolla-ansible /repository
     git -C /repository config advice.detachedHead false
     git -C /repository fetch https://review.opendev.org/openstack/kolla-ansible.git $2
     git -C /repository checkout FETCH_HEAD


### PR DESCRIPTION
We have routing issues to opendev.org at the moment.