### PR TITLE
Use bcrypt<5.0.0

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -16,6 +16,7 @@ ansible-core=={{ ansible_core_version }}
 {% endif %}
 ara=={{ osism_projects['ara'] }}
 asn1crypto==1.5.1
+bcrypt<5.0.0
 cryptography==46.0.1
 idna==3.10
 osism=={{ osism_projects['osism'] }}


### PR DESCRIPTION
Something is wrong with the latest bcrypt 5.0.0 release:

fatal: [localhost]: FAILED! => {"msg": "Task failed: Finalization of task args for 'ansible.builtin.debug' failed: Error while resolving value for 'msg': The filter plugin 'ansible.builtin.password_hash' failed: Could not hash the secret: password cannot be longer than 72 bytes, truncate manually if necessary (e.g. my_password[:72])"}

https://github.com/ansible/ansible/issues/85919