### PR TITLE
Fix horizon-always-configure-cache-backend.patch

### DIFF
--- a/patches/2024.1/horizon-always-configure-cache-backend.patch
+++ b/patches/2024.1/horizon-always-configure-cache-backend.patch
@@ -1,13 +1,13 @@
 --- a/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
 +++ b/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
-@@ -18,7 +18,16 @@ DATABASES = {
+@@ -18,8 +18,16 @@ DATABASES = {
  }
  {% elif groups['memcached'] | length > 0 and not horizon_backend_database | bool %}
  SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-+{% endif %}
 +
 +{% if groups['memcached'] | length > 0 %}
  CACHES['default']['LOCATION'] = [{% for host in groups['memcached'] %}'{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ memcached_port }}'{% if not loop.last %},{% endif %}{% endfor %}]
+ CACHES['default']['OPTIONS'] = {'ignore_exc': True}
 +CACHES['default']['OPTIONS'] =  {
 +    "no_delay": True,
 +    "ignore_exc": True,

--- a/patches/2024.2/horizon-always-configure-cache-backend.patch
+++ b/patches/2024.2/horizon-always-configure-cache-backend.patch
@@ -1,13 +1,13 @@
 --- a/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
 +++ b/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
-@@ -18,7 +18,16 @@ DATABASES = {
+@@ -18,8 +18,16 @@ DATABASES = {
  }
  {% elif groups['memcached'] | length > 0 and not horizon_backend_database | bool %}
  SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-+{% endif %}
 +
 +{% if groups['memcached'] | length > 0 %}
  CACHES['default']['LOCATION'] = [{% for host in groups['memcached'] %}'{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ memcached_port }}'{% if not loop.last %},{% endif %}{% endfor %}]
+ CACHES['default']['OPTIONS'] = {'ignore_exc': True}
 +CACHES['default']['OPTIONS'] =  {
 +    "no_delay": True,
 +    "ignore_exc": True,

--- a/patches/2025.1/horizon-always-configure-cache-backend.patch
+++ b/patches/2025.1/horizon-always-configure-cache-backend.patch
@@ -1,13 +1,13 @@
 --- a/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
 +++ b/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
-@@ -18,7 +18,16 @@ DATABASES = {
+@@ -18,8 +18,16 @@ DATABASES = {
  }
  {% elif groups['memcached'] | length > 0 and not horizon_backend_database | bool %}
  SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-+{% endif %}
 +
 +{% if groups['memcached'] | length > 0 %}
  CACHES['default']['LOCATION'] = [{% for host in groups['memcached'] %}'{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ memcached_port }}'{% if not loop.last %},{% endif %}{% endfor %}]
+ CACHES['default']['OPTIONS'] = {'ignore_exc': True}
 +CACHES['default']['OPTIONS'] =  {
 +    "no_delay": True,
 +    "ignore_exc": True,


### PR DESCRIPTION
Required because of
https://review.opendev.org/c/openstack/kolla-ansible/+/963269.