### PR TITLE
Add glance-backend-nvme.patch for 2024.2 and 2025.1

### DIFF
--- a/patches/2024.2/glance-backend-nvme.patch
+++ b/patches/2024.2/glance-backend-nvme.patch
@@ -1,0 +1,56 @@
+--- a/ansible/roles/glance/defaults/main.yml
++++ b/ansible/roles/glance/defaults/main.yml
+@@ -7,7 +7,7 @@ glance_services:
+     enabled: true
+     image: "{{ glance_api_image_full }}"
+     environment: "{{ glance_api_container_proxy }}"
+-    privileged: "{{ enable_cinder | bool and (enable_cinder_backend_iscsi | bool or cinder_backend_ceph | bool) }}"
++    privileged: "{{ enable_cinder | bool and (enable_cinder_backend_iscsi | bool or cinder_backend_ceph | bool or glance_backend_nvme | default(false) | bool) }}"
+     volumes: "{{ glance_api_default_volumes + glance_api_extra_volumes }}"
+     dimensions: "{{ glance_api_dimensions }}"
+     healthcheck: "{{ glance_api_healthcheck }}"
+@@ -201,6 +201,7 @@ glance_api_default_volumes:
+   # NOTE(yoctozepto): below to support Cinder iSCSI backends
+   - "{% if enable_cinder | bool and enable_cinder_backend_iscsi | bool %}iscsi_info:/etc/iscsi{% endif %}"
+   - "{% if enable_cinder | bool and enable_cinder_backend_iscsi | bool %}/dev:/dev{% endif %}"
++  - "{% if enable_cinder | bool and glance_backend_nvme | default(false) | bool %}/dev:/dev{% endif %}"
+ glance_tls_proxy_default_volumes:
+   - "{{ node_config_directory }}/glance-tls-proxy/:{{ container_config_directory }}/:ro"
+   - "/etc/localtime:/etc/localtime:ro"
+--- a/ansible/roles/glance/tasks/config.yml
++++ b/ansible/roles/glance/tasks/config.yml
+@@ -168,3 +168,14 @@
+   when: service | service_enabled_and_mapped_to_host
+   notify:
+     - Restart glance-tls-proxy container
++
++- name: Generating 'hostnqn' file for glance_api
++  vars:
++    service: "{{ glance_services['glance-api'] }}"
++    hostnqn: "nqn.2014-08.org.nvmexpress:uuid:{{ ansible_facts.hostname | to_uuid }}"
++  template:
++    src: "templates/hostnqn.j2"
++    dest: "{{ node_config_directory }}/glance-api/hostnqn"
++    mode: "0660"
++  become: true
++  when: service | service_enabled_and_mapped_to_host
+--- a/ansible/roles/glance/templates/glance-api.json.j2
++++ b/ansible/roles/glance/templates/glance-api.json.j2
+@@ -1,6 +1,12 @@
+ {
+     "command": "glance-api",
+     "config_files": [
++        {
++            "source": "{{ container_config_directory }}/hostnqn",
++            "dest": "/etc/nvme/hostnqn",
++            "owner": "root",
++            "perm": "0644"
++        },
+         {
+             "source": "{{ container_config_directory }}/glance-api.conf",
+             "dest": "/etc/glance/glance-api.conf",
+--- /dev/null
++++ b/ansible/roles/glance/templates/hostnqn.j2
+@@ -0,0 +1 @@
++{{ hostnqn }}
+

--- a/patches/2025.1/glance-backend-nvme.patch
+++ b/patches/2025.1/glance-backend-nvme.patch
@@ -1,0 +1,56 @@
+--- a/ansible/roles/glance/defaults/main.yml
++++ b/ansible/roles/glance/defaults/main.yml
+@@ -7,7 +7,7 @@ glance_services:
+     enabled: true
+     image: "{{ glance_api_image_full }}"
+     environment: "{{ glance_api_container_proxy }}"
+-    privileged: "{{ enable_cinder | bool and (enable_cinder_backend_iscsi | bool or cinder_backend_ceph | bool) }}"
++    privileged: "{{ enable_cinder | bool and (enable_cinder_backend_iscsi | bool or cinder_backend_ceph | bool or glance_backend_nvme | default(false) | bool) }}"
+     volumes: "{{ glance_api_default_volumes + glance_api_extra_volumes }}"
+     dimensions: "{{ glance_api_dimensions }}"
+     healthcheck: "{{ glance_api_healthcheck }}"
+@@ -208,6 +208,7 @@ glance_api_default_volumes:
+   # NOTE(yoctozepto): below to support Cinder iSCSI backends
+   - "{% if enable_cinder | bool and enable_cinder_backend_iscsi | bool %}iscsi_info:/etc/iscsi{% endif %}"
+   - "{% if enable_cinder | bool and enable_cinder_backend_iscsi | bool %}/dev:/dev{% endif %}"
++  - "{% if enable_cinder | bool and glance_backend_nvme | default(false) | bool %}/dev:/dev{% endif %}"
+ glance_tls_proxy_default_volumes:
+   - "{{ node_config_directory }}/glance-tls-proxy/:{{ container_config_directory }}/:ro"
+   - "/etc/localtime:/etc/localtime:ro"
+--- a/ansible/roles/glance/tasks/config.yml
++++ b/ansible/roles/glance/tasks/config.yml
+@@ -136,3 +136,14 @@
+     - "{{ node_custom_config }}/glance/glance-tls-proxy.cfg"
+     - "glance-tls-proxy.cfg.j2"
+   when: service | service_enabled_and_mapped_to_host
++
++- name: Generating 'hostnqn' file for glance_api
++  vars:
++    service: "{{ glance_services['glance-api'] }}"
++    hostnqn: "nqn.2014-08.org.nvmexpress:uuid:{{ ansible_facts.hostname | to_uuid }}"
++  template:
++    src: "templates/hostnqn.j2"
++    dest: "{{ node_config_directory }}/glance-api/hostnqn"
++    mode: "0660"
++  become: true
++  when: service | service_enabled_and_mapped_to_host
+--- a/ansible/roles/glance/templates/glance-api.json.j2
++++ b/ansible/roles/glance/templates/glance-api.json.j2
+@@ -1,6 +1,12 @@
+ {
+     "command": "glance-api",
+     "config_files": [
++        {
++            "source": "{{ container_config_directory }}/hostnqn",
++            "dest": "/etc/nvme/hostnqn",
++            "owner": "root",
++            "perm": "0644"
++        },
+         {
+             "source": "{{ container_config_directory }}/glance-api.conf",
+             "dest": "/etc/glance/glance-api.conf",
+index 000000000..6f1013597
+--- /dev/null
++++ b/ansible/roles/glance/templates/hostnqn.j2
+@@ -0,0 +1 @@
++{{ hostnqn }}


### PR DESCRIPTION
Enable NVMe backend support for Glance by adding privileged mode, /dev mount, and hostnqn file generation when glance_backend_nvme is enabled.