### PR TITLE
Update SBOM namespace to include OpenStack version

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -54,7 +54,7 @@
                   {% endraw %}
               fi
 
-              docker create --name sbom $registry/kolla/release/sbom:$sbom_version nologin
+              docker create --name sbom $registry/kolla/release/$openstack_version/sbom:$sbom_version nologin
               docker cp sbom:/images.yml files/sbom.yml
               docker rm sbom
           fi


### PR DESCRIPTION
The release SBOMs are now located under the new namespace structure kolla/release/OPENSTACK_VERSION/sbom instead of kolla/release/sbom.