### PR TITLE
Add patch to re-enable opensearch shard allocation

### DIFF
--- a/patches/2024.2/opensearch-re-enable-shard-allocation-after-upgrade.patch
+++ b/patches/2024.2/opensearch-re-enable-shard-allocation-after-upgrade.patch
@@ -1,0 +1,77 @@
+From da60b6e9d90eaec1b543187ba0235298b9767fbc Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Fri, 24 Apr 2026 07:45:55 +0200
+Subject: [PATCH] opensearch: re-enable shard allocation after upgrade restart
+
+The opensearch role disables shard allocation via a transient cluster
+setting (cluster.routing.allocation.enable=none) before the rolling
+restart and never re-enables it. The role relies on the transient
+being cleared by container restart, but in a rolling restart of a
+3-node (or larger) HA cluster, at least one master-eligible node
+stays up throughout, cluster state is preserved across the restart,
+and the transient persists. Replicas then stay unassigned indefinitely
+and the cluster remains YELLOW. This also blocks allocation of new
+primaries and replicas cluster-wide and compounds across upgrades.
+
+Add a symmetric 'Enable shard allocation' handler that listens on
+the same 'Restart opensearch container' topic as the disable handler
+and fires after the restart (handlers with a shared listen topic
+execute in file-declaration order). Setting the transient to null
+removes it and lets the cluster fall back to the default ('all').
+
+The 'Enable shard allocation' handler runs immediately after the
+rolling-restart phase, when the load balancer in front of opensearch
+may not yet have re-detected any backend as healthy and returns 503
+to the API call. Mirror the existing 'Perform a flush' handler's
+retry pattern (register / until result.status == 200 / retries /
+delay) so the PUT is retried until the LB recovers and opensearch
+is reachable. 30 retries * 5s delay covers up to 150s of post-
+restart instability, which is well beyond observed HAProxy +
+opensearch startup windows.
+
+Matches the user workaround documented on LP#2085943, which has been
+open and unfixed upstream since October 2024 with no Gerrit change
+attached.
+
+AI-assisted: Claude Code
+Signed-off-by: Roger Luethi <luethi@osism.tech>
+---
+ ansible/roles/opensearch/handlers/main.yml | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+diff --git a/ansible/roles/opensearch/handlers/main.yml b/ansible/roles/opensearch/handlers/main.yml
+index c088ab9..617d2ae 100644
+--- a/ansible/roles/opensearch/handlers/main.yml
++++ b/ansible/roles/opensearch/handlers/main.yml
+@@ -59,6 +59,31 @@
+   when:
+     - kolla_action != "config"
+ 
++- name: Enable shard allocation
++  become: true
++  vars:
++    opensearch_shard_body: {"transient": {"cluster.routing.allocation.enable": null}}
++  kolla_toolbox:
++    container_engine: "{{ kolla_container_engine }}"
++    module_name: uri
++    module_args:
++      url: "{{ opensearch_internal_endpoint }}/_cluster/settings"
++      method: PUT
++      status_code: 200
++      return_content: yes
++      body: "{{ opensearch_shard_body | to_json }}"
++      body_format: json
++      ca_path: "{{ openstack_cacert }}"
++  delegate_to: "{{ groups['opensearch'][0] }}"
++  run_once: true
++  retries: 30
++  delay: 5
++  register: result
++  until: ('status' in result) and result.status == 200
++  listen: "Restart opensearch container"
++  when:
++    - kolla_action == "upgrade"
++
+ - name: Restart opensearch-dashboards container
+   vars:
+     service_name: "opensearch-dashboards"

--- a/patches/2025.1/opensearch-re-enable-shard-allocation-after-upgrade.patch
+++ b/patches/2025.1/opensearch-re-enable-shard-allocation-after-upgrade.patch
@@ -1,0 +1,77 @@
+From efe6fd72d75bb22832d8a7f4753442bb3969c722 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Fri, 24 Apr 2026 07:49:52 +0200
+Subject: [PATCH] opensearch: re-enable shard allocation after upgrade restart
+
+The opensearch role disables shard allocation via a transient cluster
+setting (cluster.routing.allocation.enable=none) before the rolling
+restart and never re-enables it. The role relies on the transient
+being cleared by container restart, but in a rolling restart of a
+3-node (or larger) HA cluster, at least one master-eligible node
+stays up throughout, cluster state is preserved across the restart,
+and the transient persists. Replicas then stay unassigned indefinitely
+and the cluster remains YELLOW. This also blocks allocation of new
+primaries and replicas cluster-wide and compounds across upgrades.
+
+Add a symmetric 'Enable shard allocation' handler that listens on
+the same 'Restart opensearch container' topic as the disable handler
+and fires after the restart (handlers with a shared listen topic
+execute in file-declaration order). Setting the transient to null
+removes it and lets the cluster fall back to the default ('all').
+
+The 'Enable shard allocation' handler runs immediately after the
+rolling-restart phase, when the load balancer in front of opensearch
+may not yet have re-detected any backend as healthy and returns 503
+to the API call. Mirror the existing 'Perform a flush' handler's
+retry pattern (register / until result.status == 200 / retries /
+delay) so the PUT is retried until the LB recovers and opensearch
+is reachable. 30 retries * 5s delay covers up to 150s of post-
+restart instability, which is well beyond observed HAProxy +
+opensearch startup windows.
+
+Matches the user workaround documented on LP#2085943, which has been
+open and unfixed upstream since October 2024 with no Gerrit change
+attached.
+
+AI-assisted: Claude Code
+Signed-off-by: Roger Luethi <luethi@osism.tech>
+---
+ ansible/roles/opensearch/handlers/main.yml | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+diff --git a/ansible/roles/opensearch/handlers/main.yml b/ansible/roles/opensearch/handlers/main.yml
+index 9791d1b..2d21111 100644
+--- a/ansible/roles/opensearch/handlers/main.yml
++++ b/ansible/roles/opensearch/handlers/main.yml
+@@ -57,6 +57,31 @@
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
+ 
++- name: Enable shard allocation
++  become: true
++  vars:
++    opensearch_shard_body: {"transient": {"cluster.routing.allocation.enable": null}}
++  kolla_toolbox:
++    container_engine: "{{ kolla_container_engine }}"
++    module_name: uri
++    module_args:
++      url: "{{ opensearch_internal_endpoint }}/_cluster/settings"
++      method: PUT
++      status_code: 200
++      return_content: yes
++      body: "{{ opensearch_shard_body | to_json }}"
++      body_format: json
++      ca_path: "{{ openstack_cacert }}"
++  delegate_to: "{{ groups['opensearch'][0] }}"
++  run_once: true
++  retries: 30
++  delay: 5
++  register: result
++  until: ('status' in result) and result.status == 200
++  listen: "Restart opensearch container"
++  when:
++    - kolla_action == "upgrade"
++
+ - name: Restart opensearch-dashboards container
+   vars:
+     service_name: "opensearch-dashboards"

--- a/patches/2025.2/opensearch-re-enable-shard-allocation-after-upgrade.patch
+++ b/patches/2025.2/opensearch-re-enable-shard-allocation-after-upgrade.patch
@@ -1,0 +1,77 @@
+From 7ccad21f6a97dde542baf1be6fc235d46dc27512 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Fri, 24 Apr 2026 07:50:39 +0200
+Subject: [PATCH] opensearch: re-enable shard allocation after upgrade restart
+
+The opensearch role disables shard allocation via a transient cluster
+setting (cluster.routing.allocation.enable=none) before the rolling
+restart and never re-enables it. The role relies on the transient
+being cleared by container restart, but in a rolling restart of a
+3-node (or larger) HA cluster, at least one master-eligible node
+stays up throughout, cluster state is preserved across the restart,
+and the transient persists. Replicas then stay unassigned indefinitely
+and the cluster remains YELLOW. This also blocks allocation of new
+primaries and replicas cluster-wide and compounds across upgrades.
+
+Add a symmetric 'Enable shard allocation' handler that listens on
+the same 'Restart opensearch container' topic as the disable handler
+and fires after the restart (handlers with a shared listen topic
+execute in file-declaration order). Setting the transient to null
+removes it and lets the cluster fall back to the default ('all').
+
+The 'Enable shard allocation' handler runs immediately after the
+rolling-restart phase, when the load balancer in front of opensearch
+may not yet have re-detected any backend as healthy and returns 503
+to the API call. Mirror the existing 'Perform a flush' handler's
+retry pattern (register / until result.status == 200 / retries /
+delay) so the PUT is retried until the LB recovers and opensearch
+is reachable. 30 retries * 5s delay covers up to 150s of post-
+restart instability, which is well beyond observed HAProxy +
+opensearch startup windows.
+
+Matches the user workaround documented on LP#2085943, which has been
+open and unfixed upstream since October 2024 with no Gerrit change
+attached.
+
+AI-assisted: Claude Code
+Signed-off-by: Roger Luethi <luethi@osism.tech>
+---
+ ansible/roles/opensearch/handlers/main.yml | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+diff --git a/ansible/roles/opensearch/handlers/main.yml b/ansible/roles/opensearch/handlers/main.yml
+index 9791d1b..2d21111 100644
+--- a/ansible/roles/opensearch/handlers/main.yml
++++ b/ansible/roles/opensearch/handlers/main.yml
+@@ -57,6 +57,31 @@
+     dimensions: "{{ service.dimensions }}"
+     healthcheck: "{{ service.healthcheck | default(omit) }}"
+ 
++- name: Enable shard allocation
++  become: true
++  vars:
++    opensearch_shard_body: {"transient": {"cluster.routing.allocation.enable": null}}
++  kolla_toolbox:
++    container_engine: "{{ kolla_container_engine }}"
++    module_name: uri
++    module_args:
++      url: "{{ opensearch_internal_endpoint }}/_cluster/settings"
++      method: PUT
++      status_code: 200
++      return_content: yes
++      body: "{{ opensearch_shard_body | to_json }}"
++      body_format: json
++      ca_path: "{{ openstack_cacert }}"
++  delegate_to: "{{ groups['opensearch'][0] }}"
++  run_once: true
++  retries: 30
++  delay: 5
++  register: result
++  until: ('status' in result) and result.status == 200
++  listen: "Restart opensearch container"
++  when:
++    - kolla_action == "upgrade"
++
+ - name: Restart opensearch-dashboards container
+   vars:
+     service_name: "opensearch-dashboards"


### PR DESCRIPTION
## Summary

- Adds an `Enable shard allocation` handler to the kolla-ansible opensearch role via a local patch, fixing replicas left unassigned after rolling opensearch upgrades on 3-node (and larger) HA clusters.
- Applied to `stable/2024.2`, `stable/2025.1`, `stable/2025.2` — the three upstream branches that still exist and whose OSISM container images are actively built.
- Matches upstream [LP#2085943](https://bugs.launchpad.net/kolla-ansible/+bug/2085943) — open and unfixed since October 2024 with no Gerrit change attached.

See the commit message for the full rationale (rolling-restart race, why a post-restart symmetric handler is the right shape, observed testbed signature).

## Evidence

Most recent failing build: [Zuul](https://zuul.services.osism.tech/t/osism/build/e3575dcb7b4d491693f67ae9cd0e7556)
· [raw logs](https://logs.services.osism.tech/e35/osism/e3575dcb7b4d491693f67ae9cd0e7556/)
· [`job-output.txt`](https://logs.services.osism.tech/e35/osism/e3575dcb7b4d491693f67ae9cd0e7556/job-output.txt) (line ~48509):

```
02:25:45  OK - status: green; active_primary=9; active=22; unassigned=0
04:40:59  WARNING - status: yellow; active_primary=9; active=9; unassigned=13
```

Rare pass showing the race-dependent nature: [2026-04-12 SUCCESS](https://logs.services.osism.tech/e11/osism/e1140a0865a643d49cc225e11662d9fe/). Overall job history: [~1.5% pass rate](https://zuul.services.osism.tech/t/osism/builds?job_name=testbed-update-stable-current-ubuntu-24.04).

Upstream code: no `Enable shard allocation` anywhere in [`opensearch/handlers/main.yml`](https://opendev.org/openstack/kolla-ansible/src/branch/stable/2024.2/ansible/roles/opensearch/handlers/main.yml). The bug was introduced by the reasoning in [`e502b65b`](https://opendev.org/openstack/kolla-ansible/commit/e502b65b) ("transient will be removed once the containers are restarted" — only true for a full cluster restart, not a rolling one).

## Test plan

- [ ] Container image build succeeds for 2024.2, 2025.1, 2025.2 (CI).
- [ ] After merge and image rebuild, the next `testbed-update-stable-current-ubuntu-24.04` run logs `OK - status: green; active_primary=9; active=22; unassigned=0` at the post-upgrade ES check instead of the current `WARNING - status: yellow; active=9; unassigned=13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)