### PR TITLE
Fix NVMe and qemu-wrapper patch context

### DIFF
--- a/patches/2025.2/NOTES.md
+++ b/patches/2025.2/NOTES.md
@@ -1,3 +1,0 @@
-# Important notes
-
-* `Fix-for-overly-restrictive-permissions-on-ca-certifi.patch` has been rebased onto `Add-glance-NVMe-NQN-and-ID.patch`, because of a conflict in `glance-api.json.j2` and on `Add-option-to-deploy-qemu-wrapper-script.patch`, because of a conflict in `nova-libvirt.json.j2`


### PR DESCRIPTION
Remove `patches/2025.2/NOTES.md`, which documented that
`Fix-for-overly-restrictive-permissions-on-ca-certifi.patch` had to
be rebased onto two other patches to avoid conflicts. That patch was
dropped in #902, so the file is no longer needed.