### PR TITLE
zuul: increase push job timeout to 2700 s

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -84,6 +84,7 @@
     name: container-image-kolla-ansible-build
     pre-run: playbooks/pre.yml
     run: playbooks/build.yml
+    timeout: 2700
     vars:
       docker_namespace: osism
       docker_registry: osism.harbor.regio.digital


### PR DESCRIPTION
## Summary

- The nightly `push-2025.2` build has grown to 28–29 minutes, exceeding the default 1800 s Zuul job timeout
- The timeout fires during the final Docker layer-export step after all 35 build steps complete successfully
- Root cause: `ansible-galaxy collection install` makes sequential HTTP API calls to galaxy.ansible.com to resolve the dependency graph for 15+ collections; when galaxy.ansible.com responds slowly this phase alone exceeds 20 minutes
- `timeout: 2700` on the base job covers all push and build variants (2024.2, 2025.1, 2025.2), consistent with the same fix in [container-image-osism-ansible#744](https://github.com/osism/container-image-osism-ansible/pull/744)

## Test plan

- [ ] Verify nightly `periodic-midnight` build for `container-image-kolla-ansible-push-2025.2` completes within the new 2700 s limit
- [ ] Confirm `push-2024.2` and `push-2025.1` are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)