### PR TITLE
designate: reject empty TSIG secrets (LP#1933760)

### DIFF
--- a/patches/2024.2/designate-reject-empty-tsig-secrets.patch
+++ b/patches/2024.2/designate-reject-empty-tsig-secrets.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Thu, 22 May 2026 00:00:00 +0000
+Subject: [PATCH] designate: reject empty TSIG secrets
+
+Set allow_empty_secrets_for_tsig = false in [service:api] to enforce
+the upstream validation added in Designate 2024.2 (LP#1933760). The
+upstream default is True (permissive) for backward compatibility, but
+empty TSIG secrets provide no authentication value and the designate-
+tempest-plugin no longer skips the corresponding test (since 0.28.0).
+
+kolla-ansible stable/2024.2 is EOL upstream, so this is not a candidate
+for upstreaming; it keeps OSISM 2024.2 consistent with the other
+releases that ship the option.
+---
+
+diff --git a/ansible/roles/designate/templates/designate.conf.j2 b/ansible/roles/designate/templates/designate.conf.j2
+--- a/ansible/roles/designate/templates/designate.conf.j2
++++ b/ansible/roles/designate/templates/designate.conf.j2
+@@ -17,6 +17,7 @@
+ enable_api_admin = True
+ enable_host_header = True
+ enabled_extensions_admin = quotas, reports
++allow_empty_secrets_for_tsig = false
+
+ [keystone_authtoken]

--- a/patches/2025.1/designate-reject-empty-tsig-secrets.patch
+++ b/patches/2025.1/designate-reject-empty-tsig-secrets.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Thu, 22 May 2026 00:00:00 +0000
+Subject: [PATCH] designate: reject empty TSIG secrets
+
+Set allow_empty_secrets_for_tsig = false in [service:api] to enforce
+the upstream validation added in Designate 2024.2 (LP#1933760). The
+upstream default is True (permissive) for backward compatibility, but
+empty TSIG secrets provide no authentication value and the designate-
+tempest-plugin no longer skips the corresponding test (since 0.28.0).
+
+Candidate for upstreaming to kolla-ansible stable/2025.1.
+---
+
+diff --git a/ansible/roles/designate/templates/designate.conf.j2 b/ansible/roles/designate/templates/designate.conf.j2
+--- a/ansible/roles/designate/templates/designate.conf.j2
++++ b/ansible/roles/designate/templates/designate.conf.j2
+@@ -17,6 +17,7 @@
+ enable_api_admin = true
+ enable_host_header = true
+ enabled_extensions_admin = quotas, reports
++allow_empty_secrets_for_tsig = false
+
+ [keystone_authtoken]

--- a/patches/2025.2/designate-reject-empty-tsig-secrets.patch
+++ b/patches/2025.2/designate-reject-empty-tsig-secrets.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Thu, 22 May 2026 00:00:00 +0000
+Subject: [PATCH] designate: reject empty TSIG secrets
+
+Set allow_empty_secrets_for_tsig = false in [service:api] to enforce
+the upstream validation added in Designate 2024.2 (LP#1933760). The
+upstream default is True (permissive) for backward compatibility, but
+empty TSIG secrets provide no authentication value and the designate-
+tempest-plugin no longer skips the corresponding test (since 0.28.0).
+
+Candidate for upstreaming to kolla-ansible stable/2025.2.
+---
+
+diff --git a/ansible/roles/designate/templates/designate.conf.j2 b/ansible/roles/designate/templates/designate.conf.j2
+--- a/ansible/roles/designate/templates/designate.conf.j2
++++ b/ansible/roles/designate/templates/designate.conf.j2
+@@ -17,6 +17,7 @@
+ enable_api_admin = true
+ enable_host_header = true
+ enabled_extensions_admin = quotas, reports
++allow_empty_secrets_for_tsig = false
+
+ [keystone_authtoken]


### PR DESCRIPTION
## Problem

The OSISM kolla-ansible Designate template does not set
`allow_empty_secrets_for_tsig` in `[service:api]`. The upstream default
is `True` (permissive), so Designate accepts empty TSIG secrets and
returns HTTP 201 on tsigkey creation. The
`TestTsigkeyInvalidIdAdmin.test_create_tsigkey_for_zone_empty_secret`
tempest test expects HTTP 400, so it now fails on every run.

The test was previously guarded by a `@skip_because(bug='1933760')`
decorator. designate-tempest-plugin 0.28.0 (2026-03-18) removed that
skip on the assumption that "Fix Released" means all deployments enforce
the validation — which is only true if the operator explicitly sets
`allow_empty_secrets_for_tsig = False`.

Upstream Designate bug and fix:
- https://launchpad.net/bugs/1933760
- https://opendev.org/openstack/designate/commit/e6e1487c

## Fix

Add `allow_empty_secrets_for_tsig = false` to `[service:api]` via
patches for 2024.2, 2025.1, and 2025.2 — every release that ships the
option. The option did not exist before Designate 2024.2, so no patch
is needed for 2023.2 or 2024.1.

This is also a genuine security improvement: empty TSIG secrets provide
no authentication value and are explicitly discouraged upstream.

## Alternatives considered

**Option 1 — Exclude the test** from
`environments/openstack/files/tempest/exclude.lst`. Stops the CI noise
immediately but leaves the Designate security gap in place and hides a
real misconfiguration indefinitely.

**Option 2 — Pin designate-tempest-plugin to 0.27.x** (last version
with the skip decorator). Prevents surprise regressions from future
plugin updates but requires active maintenance on the pin and still
leaves the security gap open.

Both alternatives silence the test rather than fix the root cause. This
PR fixes the root cause.

## Why kolla-ansible upstream is not affected

kolla-ansible does not include Designate in its own CI gate — the
service does not appear in any Zuul job definition in the repo. The
template gap therefore goes undetected upstream. The 2025.1 and 2025.2
patches are candidates for upstreaming to the corresponding
kolla-ansible stable branches (stable/2025.1, stable/2025.2).
stable/2024.2 is EOL upstream, so the 2024.2 patch is not an upstreaming
candidate — it only keeps OSISM consistent across the releases that
ship the option.

## Upgrade impact

After `osism apply designate`, new tsigkey creation with an empty secret
is rejected (HTTP 400). Existing tsigkeys with empty secrets remain
functional — the validation only runs at API create/update time, not
against stored data.
