### PR TITLE
Retire OpenStack 2024.2 Dalmatian build

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -69,10 +69,6 @@
           x/ifpmiID35RCt22He7b1hP3qNN3xZ9RlYjOh6gMlLXvr9c+MiuIATVtdIKVm8=
 
 - semaphore:
-    name: semaphore-container-image-kolla-ansible-push-2024.2
-    max: 1
-
-- semaphore:
     name: semaphore-container-image-kolla-ansible-push-2025.1
     max: 1
 
@@ -90,12 +86,6 @@
       docker_registry: osism.harbor.regio.digital
 
 - job:
-    name: container-image-kolla-ansible-build-2024.2
-    parent: container-image-kolla-ansible-build
-    vars:
-      version_openstack: "2024.2"
-
-- job:
     name: container-image-kolla-ansible-build-2025.1
     parent: container-image-kolla-ansible-build
     vars:
@@ -106,20 +96,6 @@
     parent: container-image-kolla-ansible-build
     vars:
       version_openstack: "2025.2"
-
-- job:
-    name: container-image-kolla-ansible-push-2024.2
-    parent: container-image-kolla-ansible-build
-    semaphores:
-      - name: semaphore-container-image-kolla-ansible-push-2024.2
-    vars:
-      version_openstack: "2024.2"
-      push_image: true
-      push_sbom: true
-    secrets:
-      - name: secret
-        secret: SECRET_CONTAINER_IMAGE_KOLLA_ANSIBLE
-        pass-to-parent: true
 
 - job:
     name: container-image-kolla-ansible-push-2025.1
@@ -170,7 +146,6 @@
         - hadolint
         - python-black
         - yamllint
-        - container-image-kolla-ansible-build-2024.2
         - container-image-kolla-ansible-build-2025.1
         - container-image-kolla-ansible-build-2025.2
     periodic-daily:
@@ -182,13 +157,10 @@
         - yamllint
     periodic-midnight:
       jobs:
-        - container-image-kolla-ansible-push-2024.2
         - container-image-kolla-ansible-push-2025.1
         - container-image-kolla-ansible-push-2025.2
     post:
       jobs:
-        - container-image-kolla-ansible-push-2024.2:
-            branches: main
         - container-image-kolla-ansible-push-2025.1:
             branches: main
         - container-image-kolla-ansible-push-2025.2:

--- a/Containerfile
+++ b/Containerfile
@@ -130,8 +130,6 @@ mkdir -p \
 # prepare project repository
 if [ "$OPENSTACK_VERSION" = "master" ]; then
   git clone https://github.com/openstack/kolla-ansible /repository
-elif [ "$OPENSTACK_VERSION" = "2024.2" ]; then
-  git clone -b 2024.2-eol https://github.com/openstack/kolla-ansible /repository
 else
   git clone -b stable/$OPENSTACK_VERSION https://github.com/openstack/kolla-ansible /repository
 fi


### PR DESCRIPTION
## Summary

OpenStack 2024.2 Dalmatian reached end of life on 2026-04-29.
Dalmatian is a non-SLURP release, which means it moves directly to
End of Life at the end of its maintained period with no transition
through an unmaintained phase.

The upstream kolla-ansible `stable/2024.2` branch was tagged
`2024.2-eol` on 2026-05-11 and deleted from both gerrit and the
GitHub mirror shortly after.

With the branch gone, the `container-image-kolla-ansible-build-2024.2`
Zuul job has been failing on every PR check: the `git clone -b
stable/2024.2 https://github.com/openstack/kolla-ansible` step exits
immediately with code 128 (branch not found).

References:
- https://releases.openstack.org/dalmatian/index.html
- https://opendev.org/openstack/releases/src/branch/master/deliverables/dalmatian/kolla-ansible.yaml

## Changes

- Remove `container-image-kolla-ansible-build-2024.2` and
  `container-image-kolla-ansible-push-2024.2` Zuul job definitions
- Remove the corresponding semaphore
- Remove 2024.2 entries from the `check`, `periodic-midnight`, and
  `post` pipelines in `.zuul.yaml`
- Revert the `2024.2-eol` clone branch added in #909 (`3a0a4cd`) in
  the `Containerfile`. That `elif` existed only to keep the
  now-removed build job working; with the job gone it is dead code,
  and no other retired version carries such special-casing.

Build artifacts (`patches/2024.2/`, `overlays/2024.2/`) are kept in
place, consistent with how older retired versions are preserved in the
repository (e.g. 2023.2).

Tracks: https://github.com/osism/issues/issues/1367