### PR TITLE
build: use 2024.2-eol tag for kolla-ansible clone

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -128,8 +128,13 @@ mkdir -p \
   /share
 
 # prepare project repository
-if [ "$OPENSTACK_VERSION" = "master" ]; then git clone https://github.com/openstack/kolla-ansible /repository; fi
-if [ "$OPENSTACK_VERSION" != "master" ]; then git clone -b stable/$OPENSTACK_VERSION https://github.com/openstack/kolla-ansible /repository; fi
+if [ "$OPENSTACK_VERSION" = "master" ]; then
+  git clone https://github.com/openstack/kolla-ansible /repository
+elif [ "$OPENSTACK_VERSION" = "2024.2" ]; then
+  git clone -b 2024.2-eol https://github.com/openstack/kolla-ansible /repository
+else
+  git clone -b stable/$OPENSTACK_VERSION https://github.com/openstack/kolla-ansible /repository
+fi
 
 # apply patches
 for patchfile in $(find /patches/$OPENSTACK_VERSION -name "*.patch" | LC_ALL=C sort); do


### PR DESCRIPTION
## Summary

- The OpenStack 2024.2 release has reached end-of-life and the `stable/2024.2` branch in the kolla-ansible upstream repository no longer exists; the final state is preserved as the `2024.2-eol` tag.
- The Containerfile previously used `git clone -b stable/$OPENSTACK_VERSION` for all non-master versions, causing the `container-image-kolla-ansible-build-2024.2` Zuul check job to fail.
- Add an explicit `elif` branch to use the `2024.2-eol` tag when `OPENSTACK_VERSION` is `2024.2`.

Mirrors the fix applied to container-images-kolla in fffca2d.

## Test plan

- [ ] Zuul check job `container-image-kolla-ansible-build-2024.2` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)