### PR TITLE
nova: report the real error when the Libvirt checks cannot run

### DIFF
--- a/patches/2025.1/nova-libvirt-script-check-report-start-failure.patch
+++ b/patches/2025.1/nova-libvirt-script-check-report-start-failure.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Fri, 07 Aug 2026 00:00:00 +0000
+Subject: [PATCH] nova-cell: do not blame the image when the check cannot run
+
+The nova_libvirt script check starts a container to look for
+/usr/local/bin/kolla_nova_libvirt_start, also with failed_when: false,
+and its assert reads nova_libvirt_script_check.stdout | default('').
+The default keeps the play from crashing, but it makes a failed check
+indistinguishable from a check that ran and found nothing: any pull,
+daemon or SDK failure is then reported as
+
+  The nova_libvirt image '...' does not contain
+  /usr/local/bin/kolla_nova_libvirt_start ... This almost always means
+  the container image has not been updated
+
+and the operator is sent off to rebuild or re-pull an image that was
+never the problem.
+
+Fail before the assert, with the module's own message, when the check
+container did not run at all. When it did run and the file is absent
+the module reports a non-zero return code together with stdout, so the
+existing assert still fires with its (then correct) message.
+
+This block exists only on the stable branches: it was added during the
+backports of "Start virtlogd in nova-libvirt and route console logs to
+it." at a reviewer's request, to catch new Kolla-Ansible code running
+against old images, and has no equivalent on master.
+
+Candidate for upstreaming to kolla-ansible stable/2025.1, stable/2025.2
+and stable/2026.1.
+---
+
+diff --git a/ansible/roles/nova-cell/tasks/version-check.yml b/ansible/roles/nova-cell/tasks/version-check.yml
+--- a/ansible/roles/nova-cell/tasks/version-check.yml
++++ b/ansible/roles/nova-cell/tasks/version-check.yml
+@@ -97,6 +97,17 @@
+       run_once: true
+       delegate_to: "{{ groups[service.group] | first }}"
+ 
++    - name: Fail if the nova_libvirt image could not be inspected
++      fail:
++        msg: >-
++          Could not check the nova_libvirt image {{ service.image }} for
++          /usr/local/bin/kolla_nova_libvirt_start: the check container did not
++          run, so nothing is known about the image content. Error reported by
++          the container start: {{ nova_libvirt_script_check.msg | default('none') }}
++      when: nova_libvirt_script_check.stdout is not defined
++      run_once: true
++      delegate_to: "{{ groups[service.group] | first }}"
++
+     - name: Assert the nova_libvirt image is recent enough
+       run_once: true
+       delegate_to: "{{ groups[service.group] | first }}"

--- a/patches/2025.1/nova-libvirt-version-check-report-start-failure.patch
+++ b/patches/2025.1/nova-libvirt-version-check-report-start-failure.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Fri, 07 Aug 2026 00:00:00 +0000
+Subject: [PATCH] nova-cell: report why the Libvirt version check failed
+
+The "Get new Libvirt version" task starts a throwaway container to read
+libvirtd --version with failed_when: false, and the next task templates
+libvirt_version_new.stdout. The module only adds stdout to its result
+after the container has been waited on, so any earlier failure - image
+pull, container create, oneshot start, or an exception in the module
+itself - leaves a result carrying only msg. failed_when: false then
+reports that failure as green, and "Cache new Libvirt version" dies with
+
+  The task includes an option with an undefined variable..
+  'dict object' has no attribute 'stdout'
+
+which names the wrong task and says nothing about the actual error. The
+real error is in libvirt_version_new.msg and is only visible at -vv.
+
+Default stdout so the fact templating cannot fail, and add an explicit
+task that fails with the module's own message when no version could be
+determined. That also covers output the regex cannot parse, which would
+otherwise reach the version comparison as an empty string and produce
+the next confusing error.
+
+The condition tests the registered stdout rather than the cached fact,
+so it does not depend on how an unmatched regex_search renders (empty
+string on ansible-core 2.18, None under native Jinja).
+
+Candidate for upstreaming to kolla-ansible master and stable branches.
+---
+
+diff --git a/ansible/roles/nova-cell/tasks/version-check.yml b/ansible/roles/nova-cell/tasks/version-check.yml
+--- a/ansible/roles/nova-cell/tasks/version-check.yml
++++ b/ansible/roles/nova-cell/tasks/version-check.yml
+@@ -22,11 +22,25 @@
+ 
+     - name: Cache new Libvirt version
+       set_fact:
+-        libvirt_new_version: "{{ libvirt_version_new.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
++        libvirt_new_version: "{{ libvirt_version_new.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+       run_once: true
+       delegate_facts: true
+       delegate_to: "{{ groups[service.group] | first }}"
+ 
++    - name: Fail if the new Libvirt version could not be determined
++      any_errors_fatal: true
++      fail:
++        msg: >-
++          Could not determine the Libvirt version of the new nova_libvirt image
++          {{ service.image }}: the version check container produced no usable
++          version string. This is not a Libvirt downgrade, and it is not an
++          image content problem - the check itself did not complete. Error
++          reported by the container start: {{ libvirt_version_new.msg | default('none') }}
++          Container output: '{{ libvirt_version_new.stdout | default('') | trim }}'
++      when: libvirt_version_new.stdout | default('') is not search('[0-9]+\.[0-9]+\.[0-9]+')
++      run_once: true
++      delegate_to: "{{ groups[service.group] | first }}"
++
+     - name: Get nova_libvirt image info
+       include_role:
+         name: service-image-info

--- a/patches/2025.2/nova-libvirt-script-check-report-start-failure.patch
+++ b/patches/2025.2/nova-libvirt-script-check-report-start-failure.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Fri, 07 Aug 2026 00:00:00 +0000
+Subject: [PATCH] nova-cell: do not blame the image when the check cannot run
+
+The nova_libvirt script check starts a container to look for
+/usr/local/bin/kolla_nova_libvirt_start, also with failed_when: false,
+and its assert reads nova_libvirt_script_check.stdout | default('').
+The default keeps the play from crashing, but it makes a failed check
+indistinguishable from a check that ran and found nothing: any pull,
+daemon or SDK failure is then reported as
+
+  The nova_libvirt image '...' does not contain
+  /usr/local/bin/kolla_nova_libvirt_start ... This almost always means
+  the container image has not been updated
+
+and the operator is sent off to rebuild or re-pull an image that was
+never the problem.
+
+Fail before the assert, with the module's own message, when the check
+container did not run at all. When it did run and the file is absent
+the module reports a non-zero return code together with stdout, so the
+existing assert still fires with its (then correct) message.
+
+This block exists only on the stable branches: it was added during the
+backports of "Start virtlogd in nova-libvirt and route console logs to
+it." at a reviewer's request, to catch new Kolla-Ansible code running
+against old images, and has no equivalent on master.
+
+Candidate for upstreaming to kolla-ansible stable/2025.1, stable/2025.2
+and stable/2026.1.
+---
+
+diff --git a/ansible/roles/nova-cell/tasks/version-check.yml b/ansible/roles/nova-cell/tasks/version-check.yml
+--- a/ansible/roles/nova-cell/tasks/version-check.yml
++++ b/ansible/roles/nova-cell/tasks/version-check.yml
+@@ -97,6 +97,17 @@
+       run_once: true
+       delegate_to: "{{ groups[service.group] | first }}"
+ 
++    - name: Fail if the nova_libvirt image could not be inspected
++      fail:
++        msg: >-
++          Could not check the nova_libvirt image {{ service.image }} for
++          /usr/local/bin/kolla_nova_libvirt_start: the check container did not
++          run, so nothing is known about the image content. Error reported by
++          the container start: {{ nova_libvirt_script_check.msg | default('none') }}
++      when: nova_libvirt_script_check.stdout is not defined
++      run_once: true
++      delegate_to: "{{ groups[service.group] | first }}"
++
+     - name: Assert the nova_libvirt image is recent enough
+       run_once: true
+       delegate_to: "{{ groups[service.group] | first }}"

--- a/patches/2025.2/nova-libvirt-version-check-report-start-failure.patch
+++ b/patches/2025.2/nova-libvirt-version-check-report-start-failure.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Luethi <luethi@osism.tech>
+Date: Fri, 07 Aug 2026 00:00:00 +0000
+Subject: [PATCH] nova-cell: report why the Libvirt version check failed
+
+The "Get new Libvirt version" task starts a throwaway container to read
+libvirtd --version with failed_when: false, and the next task templates
+libvirt_version_new.stdout. The module only adds stdout to its result
+after the container has been waited on, so any earlier failure - image
+pull, container create, oneshot start, or an exception in the module
+itself - leaves a result carrying only msg. failed_when: false then
+reports that failure as green, and "Cache new Libvirt version" dies with
+
+  The task includes an option with an undefined variable..
+  'dict object' has no attribute 'stdout'
+
+which names the wrong task and says nothing about the actual error. The
+real error is in libvirt_version_new.msg and is only visible at -vv.
+
+Default stdout so the fact templating cannot fail, and add an explicit
+task that fails with the module's own message when no version could be
+determined. That also covers output the regex cannot parse, which would
+otherwise reach the version comparison as an empty string and produce
+the next confusing error.
+
+The condition tests the registered stdout rather than the cached fact,
+so it does not depend on how an unmatched regex_search renders (empty
+string on ansible-core 2.18, None under native Jinja).
+
+Candidate for upstreaming to kolla-ansible master and stable branches.
+---
+
+diff --git a/ansible/roles/nova-cell/tasks/version-check.yml b/ansible/roles/nova-cell/tasks/version-check.yml
+--- a/ansible/roles/nova-cell/tasks/version-check.yml
++++ b/ansible/roles/nova-cell/tasks/version-check.yml
+@@ -22,11 +22,25 @@
+ 
+     - name: Cache new Libvirt version
+       set_fact:
+-        libvirt_new_version: "{{ libvirt_version_new.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
++        libvirt_new_version: "{{ libvirt_version_new.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+       run_once: true
+       delegate_facts: true
+       delegate_to: "{{ groups[service.group] | first }}"
+ 
++    - name: Fail if the new Libvirt version could not be determined
++      any_errors_fatal: true
++      fail:
++        msg: >-
++          Could not determine the Libvirt version of the new nova_libvirt image
++          {{ service.image }}: the version check container produced no usable
++          version string. This is not a Libvirt downgrade, and it is not an
++          image content problem - the check itself did not complete. Error
++          reported by the container start: {{ libvirt_version_new.msg | default('none') }}
++          Container output: '{{ libvirt_version_new.stdout | default('') | trim }}'
++      when: libvirt_version_new.stdout | default('') is not search('[0-9]+\.[0-9]+\.[0-9]+')
++      run_once: true
++      delegate_to: "{{ groups[service.group] | first }}"
++
+     - name: Get nova_libvirt image info
+       include_role:
+         name: service-image-info


### PR DESCRIPTION
kolla-ansible's `nova-cell` version check starts throwaway containers with
`failed_when: false` and then consumes the registered result as if it had
succeeded. When the container start fails — image pull, container create,
oneshot start, or an exception inside `kolla_container` itself — the result
carries only `msg`, never `stdout`, and the real error is thrown away in favour
of a misleading one.

Two sibling blocks in `ansible/roles/nova-cell/tasks/version-check.yml` have the
pattern, one patch each:

| producer → consumer | consumer expression | what the operator sees today |
|---|---|---|
| `Get new Libvirt version` → `Cache new Libvirt version` | `libvirt_version_new.stdout`, unguarded | play dies with `'dict object' has no attribute 'stdout'`, pointing at the **wrong task** |
| `Look for kolla_nova_libvirt_start in the nova_libvirt image` → `Assert the nova_libvirt image is recent enough` | `nova_libvirt_script_check.stdout \| default('')` | assert fails with *"…the container image has not been updated"* — a **confidently wrong diagnosis** |

The second is the worse of the two: it does not crash, it sends the operator off
to rebuild or re-pull an image that was never the problem.

This is reachable on every OSISM compute node. The block is gated on
`enable_nova_libvirt_container`, which OSISM leaves at the kolla default with
`nova_compute_virt_type: kvm`, and the version check is the *first* thing
`nova-cell` does (`deploy.yml:5`) — so on an upgrade it is the first moment a
compute node ever asks the registry for the new `nova-libvirt` tag.

## Root cause

`stdout` is added to the module result only at the very end of
`start_container()`, in the `not detach` branch
(`ansible/module_utils/kolla_docker_worker.py:396-405`):

```python
if not self.check_image():
    self.pull_image()          # registry/mirror problems land here
…
    self.create_container()    # name conflicts, daemon errors
…
    self.dc.start(…)           # oneshot start
if not self.params.get('detach'):
    rc = self.dc.wait(…)
    self.result['stdout'] = self.dc.logs(…)   # first point stdout exists
```

Everything before that line fails `stdout`-less. `failed_when: false` rewrites
that failure into a green `changed` result, and the consumer then templates
`.stdout` on a dict that holds only `msg`. A container exiting non-zero is *not*
affected — that path reports `stdout` — which pins the masked window to strictly
before `dc.wait()`.

The error is hidden, not lost: Ansible prints it at verbosity ≥ 1. Under OSISM
that needs `osism apply nova -- -vv`, because the `osism` CLI consumes a bare
`-v` itself.

## Evidence

Reproduced end to end on a live, supported OSISM cluster (tbng/regiocloud, OSISM
`0.20260729.1`, OpenStack 2025.2, all Ubuntu 24.04) by pointing the image at an
unreachable registry:

```
osism apply nova --tags nova-cell \
  -e nova_libvirt_image_full=127.0.0.1:1/kolla/nova-libvirt:no-such-tag
```

`Get new Libvirt version` reported `changed: [testbed-node-3]` — green, no
warning — and the next task produced the reported message character for
character. The ARA record of the swallowed result has content keys
`['changed', 'failed_when_result', 'invocation', 'msg']`, no `stdout`, with the
real traceback (`start_container()` → `pull_image()` → `docker.errors.APIError:
500 … connection refused`) in `msg`.

## Verification

- **Applies clean.** Replicated the Containerfile loop (`patch --forward
  --batch -p1` over `LC_ALL=C sort`, dry-run then apply) against fresh
  `stable/2025.1` and `stable/2025.2` trees with the complete patch set — 28 and
  25 patches — all applying with no failures, and the resulting
  `version-check.yml` matching the intended content. No other OSISM patch
  touches this file.
- **Three live `nova-cell` applies on the tbng 2025.2 cluster**, patched file
  `docker cp`'d into the `kolla-ansible` container, stock file restored and md5
  confirmed afterwards:
  1. Unreachable registry → fails in *Fail if the new Libvirt version could not
     be determined* with the docker `APIError` from the pull, **at default
     verbosity**, instead of `'dict object' has no attribute 'stdout'`.
  2. Unreachable registry plus `--skip-tags nova-libvirt-version-check`, so the
     script check is reached → fails in *Fail if the nova_libvirt image could
     not be inspected*, and the stale-image assert does **not** fire (0
     occurrences of "does not contain").
  3. Unmodified run → `exit 0`, `failed=0`, both new tasks skipped, `nova-cell`
     converges as before. Cluster re-converged clean.
- **Ansible semantics.** The version-check condition tests the registered
  `stdout` with `is not search(...)` rather than the cached fact, so it does not
  depend on how an unmatched `regex_search` renders (empty string on
  ansible-core 2.18, `None` under native Jinja 2.19+). It also catches container
  output the regex cannot parse, which would otherwise reach the version
  comparison as an empty string and produce the next confusing error.

## Scope

Only `patches/2025.1/` and `patches/2025.2/`: the version check landed in
kolla-ansible `stable/2025.1` and does not exist in 2023.2, 2024.1 or 2024.2,
and there is no `patches/2026.1/` here yet. The two files are byte-identical
between the release directories — upstream `version-check.yml` is identical on
both branches.

Both patches keep the Libvirt-downgrade guard itself intact; they only make the
failure path honest.

## Upstream

Deliberately trialled here first. Nothing is filed on Launchpad or Gerrit yet —
the intent is to let these prove themselves downstream, then propose site 1 to
`master` with backports and site 2 directly to the stable branches (`master` has
no script-check block; it was added during the backports at a reviewer's
request, <https://review.opendev.org/c/openstack/kolla-ansible/+/993458>). A
`master` change will also need FQCN (`ansible.builtin.fail`), which the stable
branches do not.

Nothing in 12 patchsets of review on
<https://review.opendev.org/c/openstack/kolla-ansible/+/942925>, in the original
commit, or in bug #2120290 ever mentions `failed_when: false` — so there is no
intended behaviour being changed here.

Related:

- osism/issues#1431

Draft: opened for review while the reporting client's actual `msg` is still
outstanding; the patches stand on their own, but a second opinion on the wording
of the two new failure messages is welcome before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
