### PR TITLE
wait-for: bound the port wait with a timeout

### DIFF
--- a/files/playbooks/kolla-wait-for-keystone.yml
+++ b/files/playbooks/kolla-wait-for-keystone.yml
@@ -29,7 +29,4 @@
         host: "{{ api_interface_address }}"
         port: "{{ keystone_public_listen_port }}"
         connect_timeout: 1
-      register: check_keystone_public_port
-      until: check_keystone_public_port is success
-      retries: 60
-      delay: 10
+        timeout: 900

--- a/files/playbooks/kolla-wait-for-nova.yml
+++ b/files/playbooks/kolla-wait-for-nova.yml
@@ -29,7 +29,4 @@
         host: "{{ api_interface_address }}"
         port: "{{ nova_api_public_port }}"
         connect_timeout: 1
-      register: check_nova_public_port
-      until: check_nova_public_port is success
-      retries: 60
-      delay: 10
+        timeout: 900


### PR DESCRIPTION
`kolla-wait-for-nova.yml` and `kolla-wait-for-keystone.yml` wait for the service port with `ansible.builtin.wait_for` wrapped in an `until` retry loop:

```yaml
  ansible.builtin.wait_for:
    host: "{{ api_interface_address }}"
    port: "{{ nova_api_public_port }}"
    connect_timeout: 1
  register: check_nova_public_port
  until: check_nova_public_port is success
  retries: 60
  delay: 10
```

`retries: 60` with `delay: 10` reads as a 10-minute bound. It is not one.

## The bug

`wait_for` has its own internal poll loop, bounded by its own `timeout` parameter — unset here, so it defaults to **300s**. A closed port does not fail fast; `wait_for` keeps polling for the whole timeout before returning failed. Each of the 60 `until` attempts therefore costs 300s, not the ~0s the retries/delay pair assumes:

```
60 x 300s + 59 x 10s = 18590s = 5h 09m 50s
```

`connect_timeout: 1` does not help — it bounds a single socket connect attempt inside `wait_for`, not the module's overall run.

The practical consequence is that **the play can never give up on its own in CI**, because 5h09m50s exceeds the 4h30m Zuul job timeout. It has never once been observed reaching its own limit. With `kolla_serial` set to a non-zero value the bound multiplies by the number of batches.

Measured with ansible-core 2.18.17 against a port with nothing listening:

| config | result |
|---|---|
| bare `wait_for`, `timeout: 5`, `connect_timeout: 1` | `elapsed: 5` — consumes the full timeout, does **not** fail fast on connection-refused |
| `timeout: 3` + `until` / `retries: 3` / `delay: 2` | `attempts: 3`, ~13s wall — the wrapper multiplies |

Both halves of the arithmetic hold. Seen most recently in build [`7e89e00b`](https://zuul.services.osism.tech/t/osism/build/7e89e00ba83d48b79d9df204cb1cbd2e) (2026-08-27), where keystone failed permanently at 01:02:41 and `wait-for-keystone` was still polling when the job was killed at 04:30:26, 3h26m later, having emitted nothing to the job log.

## The fix

Drop the `until` / `retries` / `delay` wrapper and set `timeout: 900` on the module instead. `wait_for` already polls internally, so the wrapper contributed nothing except the multiplication.

`900` is deliberately generous. The values being replaced read as an intended 600s bound, and a port that is going to open at all normally does so within seconds of the service container starting; 900s leaves wide margin for a slow or loaded deploy without regressing it. What it gives up is the `FAILED - RETRYING` progress lines, so a wait that is going to fail is now silent until it does — an acceptable trade for a bound that can actually be reached.

Both files `ansible-playbook --syntax-check` clean; yamllint passes at the version pinned in `.zuul.yaml`. There are no per-release copies of these two playbooks to keep in sync.

## Relationship to the chain-abort fix

These two defects co-fire but are independent, and neither is defense-in-depth for the other:

- osism/python-osism#2630

That one is the load-bearing fix for the 4h31m timeouts: a kolla-ansible play that fails still reports celery `SUCCESS`, so the collection chain carries on regardless. **This** change does not fix that — with the wait bounded to minutes, the chain still carries on past a failed play, every task still reports `SUCCESS`, and the deploy still reports success; the job would just proceed to run tempest against a broken cloud instead of timing out.

Conversely that fix does not make this one unnecessary. It makes this bound unreachable on *that* path, but this defect survives it whenever nothing upstream fails: every play succeeds, yet the service never binds its port (wrong `api_interface_address`, a container that starts and immediately exits, a listener on the wrong interface). There is no Ansible failure to propagate, so this bound alone decides how long the deploy sits there.

Note these two playbooks are OSISM's own — upstream `openstack/kolla-ansible` has no wait-for playbooks — so there is no upstream to carry the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
